### PR TITLE
Refactor lot of things.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# EditorConfig: http://EditorConfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,46 @@
+{
+	"env": {
+		"node": true
+	},
+
+	"plugins": [
+		"nodeca"
+	],
+
+	"rules": {
+		"brace-style": [2, "1tbs"],
+		"default-case": 2,
+		"camelcase": 2,
+		"consistent-this": [2, "self"],
+		"dot-notation": 0,
+		"eol-last": 2,
+		"func-names": 2,
+		"func-style": [2, "declaration"],
+		"guard-for-in": 2,
+		"new-cap": 0,
+		"no-floating-decimal": 2,
+		"no-lonely-if": 2,
+		"no-mixed-spaces-and-tabs": [2, true],
+		"no-nested-ternary": 2,
+		"no-use-before-define": 2,
+		"no-undefined": 2,
+		"no-underscore-dangle": 0,
+		"nodeca/indent": [2, "tabs", 1],
+		"nodeca/no-lodash-aliases": 2,
+		"quotes": [2, "single"],
+		"radix": 2,
+		"space-after-keywords": [2, "always"],
+		"valid-jsdoc": [2, {
+			"prefer": {
+				"return": "returns"
+			}
+		}],
+		"wrap-iife": 2,
+		"yoda": [0, "always"]
+	},
+
+	"globals": {
+		"console": false,
+		"Promise": true
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/node_modules/
-/dist/
+node_modules
+coverage
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: node_js
+node_js:
+- '0.12'
+- '0.10'
+- 'iojs-1'
+before_install:
+- npm install -g "npm@>=1.4.6"
+after_success:
+- npm install coveralls
+- cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 HTML Webpack Plugin
 ===================
 
-This is a [webpack](http://webpack.github.io/) plugin that simplifies creation of HTML files to serve your
-webpack bundles. This is especially useful for webpack bundles that include
-a hash in the filename which changes every compilation. You can either let the plugin generate an HTML file for you or supply
-your own template (using [blueimp templates](https://github.com/blueimp/JavaScript-Templates)).
+![build status](http://img.shields.io/travis/ampedandwired/html-webpack-plugin/master.svg?style=flat)
+![coverage](http://img.shields.io/coveralls/ampedandwired/html-webpack-plugin/master.svg?style=flat)
+![license](http://img.shields.io/npm/l/html-webpack-plugin.svg?style=flat)
+![version](http://img.shields.io/npm/v/html-webpack-plugin.svg?style=flat)
+![downloads](http://img.shields.io/npm/dm/html-webpack-plugin.svg?style=flat)
+
+This is a [webpack](http://webpack.github.io/) plugin that simplifies creation of HTML files to serve your webpack bundles. This is especially useful for webpack bundles that include a hash in the filename which changes every compilation. You can either let the plugin generate an HTML file for you or supply your own template (using [lodash templates](https://lodash.com/docs#template)).
 
 Installation
 ------------
@@ -17,9 +20,7 @@ $ npm install html-webpack-plugin --save-dev
 Basic Usage
 -----------
 
-The plugin will generate an HTML5 file for you that includes all your webpack
-bundles in the body using `script` tags. Just add the plugin to your webpack
-config as follows:
+The plugin will generate an HTML5 file for you that includes all your webpack bundles in the body using `script` tags. Just add the plugin to your webpack config as follows:
 
 ```javascript
 var HtmlWebpackPlugin = require('html-webpack-plugin')
@@ -34,6 +35,7 @@ var webpackConfig = {
 ```
 
 This will generate a file `dist/index.html` containing the following:
+
 ```html
 <!DOCTYPE html>
 <html>
@@ -47,18 +49,15 @@ This will generate a file `dist/index.html` containing the following:
 </html>
 ```
 
-If you have multiple webpack entry points, they will all be included with `script`
-tags in the generated HTML.
+If you have multiple webpack entry points, they will all be included with `script` tags in the generated HTML.
 
 
 Configuration
 -------------
-You can pass a hash of configuration options to `HtmlWebpackPlugin`.
-Allowed values are as follows:
+You can pass a hash of configuration options to `HtmlWebpackPlugin`.Allowed values are as follows:
 
 - `title`: The title to use for the generated HTML document.
-- `filename`: The file to write the HTML to. Defaults to `index.html`.
-   You can specify a subdirectory here too (eg: `assets/admin.html`).
+- `filename`: The file to write the HTML to. Defaults to `index.html`. You can specify a subdirectory here too (eg: `assets/admin.html`).
 
 Here's an example webpack config illustrating how to use these options:
 ```javascript
@@ -79,8 +78,7 @@ Here's an example webpack config illustrating how to use these options:
 
 Generating Multiple HTML Files
 ------------------------------
-To generate more than one HTML file, declare the plugin more than
-once in your plugins array:
+To generate more than one HTML file, declare the plugin more than once in your plugins array:
 ```javascript
 {
   entry: 'index.js',
@@ -92,7 +90,7 @@ once in your plugins array:
     new HtmlWebpackPlugin(), // Generates default index.html
     new HtmlWebpackPlugin({  // Also generate a test.html
       filename: 'test.html',
-      template: 'src/assets/test.html'
+      template: fs.readFileSync('src/assets/test.html')
     })
   ]
 }
@@ -100,13 +98,10 @@ once in your plugins array:
 
 Writing Your Own Templates
 --------------------------
-If the default generated HTML doesn't meet your needs you can supply
-your own [blueimp template](https://github.com/blueimp/JavaScript-Templates).
-The [default template](https://github.com/ampedandwired/html-webpack-plugin/blob/master/default_index.html)
+If the default generated HTML doesn't meet your needs you can supply your own [lodash template](https://lodash.com/docs#template). The [default template](https://github.com/ampedandwired/html-webpack-plugin/blob/master/default_index.html)
 is a good starting point for writing your own.
 
-Let's say for example you wanted to put a webpack bundle into the head of your
-HTML as well as the body. Your template might look like this:
+Let's say for example you wanted to put a webpack bundle into the head of your HTML as well as the body. Your template might look like this:
 ```html
 <!DOCTYPE html>
 <html>
@@ -131,47 +126,17 @@ To use this template, configure the plugin like this:
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: 'src/assets/my_template.html'
+      template: fs.readFileSync('src/assets/my_template.html')
     })
   ]
 }
 ```
 
-Alternatively, if you already have your template's content in a String, you
-can pass it to the plugin using the `templateContent` option:
+Alternatively, if you already have your template's content in a string, you can pass it to the plugin using the `template` option:
 ```javascript
 plugins: [
   new HtmlWebpackPlugin({
-    templateContent: templateContentString
+    template: '<html>...</html>'
   })
 ]
 ```
-
-Note the plugin will throw an error if you specify both `template` _and_
-`templateContent`.
-
-The `o` variable in the template is the data that is passed in when the
-template is rendered. This variable has the following attributes:
-- `htmlWebpackPlugin`: data specific to this plugin
-  - `htmlWebpackPlugin.assets`: a massaged representation of the
-    `assetsByChunkName` attribute of webpack's [stats](https://github.com/webpack/docs/wiki/node.js-api#stats)
-    object. It contains a mapping from entry point name to the bundle filename, eg:
-    ```json
-    "htmlWebpackPlugin": {
-      "assets": {
-        "head": "assets/head_bundle.js",
-        "main": "assets/main_bundle.js"
-      }
-    }
-    ```
-    If you've set a publicPath in your webpack config this will be reflected
-    correctly in this assets hash.
-
-  - `htmlWebpackPlugin.options`: the options hash that was passed to
-     the plugin. In addition to the options actually used by this plugin,
-     you can use this hash to pass arbitrary data through to your template.
-
-- `webpack`: the webpack [stats](https://github.com/webpack/docs/wiki/node.js-api#stats)
-  object. Note that this is the stats object as it was at the time the HTML template
-  was emitted and as such may not have the full set of stats that are available
-  after the wepback run is complete.

--- a/default_index.html
+++ b/default_index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8">
-    <title>{%=o.htmlWebpackPlugin.options.title || 'Webpack App'%}</title>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+    <title><%=title%></title>
   </head>
   <body>
-    {% for (var chunk in o.htmlWebpackPlugin.assets) { %}
-    <script src="{%=o.htmlWebpackPlugin.assets[chunk]%}"></script>
-    {% } %}
+    <!-- Load all the assets from webpack. -->
+    <% _.forEach(paths, function(path) { %>
+      <script src="<%=path%>"></script>
+    <% }); %>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,34 +1,37 @@
 {
-  "name": "html-webpack-plugin",
-  "version": "1.1.0",
-  "description": "Simplifies creation of HTML files to serve your webpack bundles",
-  "main": "index.js",
-  "scripts": {
-    "test": "jshint *.js spec && jasmine-node --captureExceptions spec"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ampedandwired/html-webpack-plugin.git"
-  },
-  "keywords": [
-    "webpack",
-    "plugin",
-    "html",
-    "generate"
-  ],
-  "author": "Charles Blaxland <charles.blaxland@gmail.com> (https://github.com/ampedandwired)",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/ampedandwired/html-webpack-plugin/issues"
-  },
-  "homepage": "https://github.com/ampedandwired/html-webpack-plugin",
-  "devDependencies": {
-    "jasmine-node": "^1.14.5",
-    "jshint": "^2.5.2",
-    "rimraf": "^2.2.8",
-    "webpack": "^1.3.3-beta1"
-  },
-  "dependencies": {
-    "blueimp-tmpl": "~2.5.4"
-  }
+    "name": "html-webpack-plugin",
+    "version": "2.0.0",
+    "description": "Simplifies creation of HTML files to serve your webpack bundles.",
+    "author": "Charles Blaxland <charles.blaxland@gmail.com> (https://github.com/ampedandwired)",
+    "keywords": [ "webpack", "html", "static" ],
+    "license": "MIT",
+    "homepage": "https://github.com/ampedandwired/html-webpack-plugin",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ampedandwired/html-webpack-plugin.git"
+    },
+    "main": "index.js",
+    "scripts": {
+        "test": "npm run lint && npm run spec && npm run coverage",
+        "spec": "NODE_ENV=test istanbul cover -x **/spec/** node_modules/.bin/jasmine-node --captureExceptions spec",
+        "lint": "eslint --ignore-path .gitignore .",
+        "coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
+    },
+    "dependencies": {
+        "lodash": "^3.2.0",
+        "html-minifier": "^0.7.0"
+    },
+    "devDependencies": {
+        "eslint": "^0.14.0",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "istanbul": "^0.3.5",
+        "jasmine-node": "^1.14.5",
+        "jshint": "^2.5.2",
+        "rimraf": "^2.2.8",
+        "webpack": "^1.5.3"
+    },
+    "engines": {
+        "node": "^0.8 || ^0.11 || ^0.12",
+        "iojs": "^1.0.0"
+    }
 }

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -1,0 +1,14 @@
+{
+	"globals": {
+		"describe": true,
+		"beforeEach": true,
+		"afterEach": true,
+		"it": true,
+		"expect": true
+	},
+
+	"rules": {
+		"func-names": 0,
+		"no-unused-expressions": 0
+	}
+}

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -1,229 +1,218 @@
+
+'use strict';
+
 var path = require('path');
 var fs = require('fs');
 var webpack = require('webpack');
-var rm_rf = require('rimraf');
+var rimraf = require('rimraf');
 var HtmlWebpackPlugin = require('../index.js');
 
 var OUTPUT_DIR = path.join(__dirname, '../dist');
 
 function testHtmlPlugin(webpackConfig, expectedResults, outputFile, done) {
-  outputFile = outputFile || 'index.html';
-  webpack(webpackConfig, function(err, stats) {
-    expect(err).toBeFalsy();
-    expect(stats.hasErrors()).toBe(false);
-    var htmlContent = fs.readFileSync(path.join(OUTPUT_DIR, outputFile)).toString();
-    for (var i = 0; i < expectedResults.length; i++) {
-      var expectedResult = expectedResults[i];
-      if (expectedResult instanceof RegExp) {
-        expect(htmlContent).toMatch(expectedResult);
-      } else {
-        expect(htmlContent).toContain(expectedResult);
-      }
-    }
-    done();
-  });
+	outputFile = outputFile || 'index.html';
+	webpack(webpackConfig, function(err, stats) {
+		expect(err).toBeFalsy();
+		expect(stats.hasErrors()).toBe(false);
+		var htmlContent = fs.readFileSync(path.join(OUTPUT_DIR, outputFile)).toString();
+		for (var i = 0; i < expectedResults.length; i++) {
+			var expectedResult = expectedResults[i];
+			if (expectedResult instanceof RegExp) {
+				expect(htmlContent).toMatch(expectedResult);
+			} else {
+				expect(htmlContent).toContain(expectedResult);
+			}
+		}
+		done();
+	});
 }
 
 describe('HtmlWebpackPlugin', function() {
-  beforeEach(function(done) {
-    rm_rf(OUTPUT_DIR, done);
-  });
+	beforeEach(function(done) {
+		rimraf(OUTPUT_DIR, done);
+	});
 
-  it('generates a default index.html file for a single entry point', function(done) {
-    testHtmlPlugin({
-      entry: path.join(__dirname, 'fixtures/index.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'index_bundle.js'
-      },
-      plugins: [new HtmlWebpackPlugin()]
-    }, ['<script src="index_bundle.js"'], null, done);
+	it('generates a default index.html file for a single entry point', function(done) {
+		testHtmlPlugin({
+			entry: path.join(__dirname, 'fixtures/index.js'),
+			output: {
+				path: OUTPUT_DIR,
+				filename: 'index_bundle.js'
+			},
+			plugins: [new HtmlWebpackPlugin()]
+		}, ['<script src="index_bundle.js"'], null, done);
+	});
 
-  });
+	it('generates a default index.html file with multiple entry points', function(done) {
+		testHtmlPlugin({
+			entry: {
+				util: path.join(__dirname, 'fixtures/util.js'),
+				app: path.join(__dirname, 'fixtures/index.js')
+			},
+			output: {
+				path: OUTPUT_DIR,
+				filename: '[name]_bundle.js'
+			},
+			plugins: [new HtmlWebpackPlugin()]
+		}, ['<script src="util_bundle.js"', '<script src="app_bundle.js"'], null, done);
+	});
 
-  it('generates a default index.html file with multiple entry points', function(done) {
-    testHtmlPlugin({
-      entry: {
-        util: path.join(__dirname, 'fixtures/util.js'),
-        app: path.join(__dirname, 'fixtures/index.js')
-      },
-      output: {
-        path: OUTPUT_DIR,
-        filename: '[name]_bundle.js'
-      },
-      plugins: [new HtmlWebpackPlugin()]
-    }, ['<script src="util_bundle.js"', '<script src="app_bundle.js"'], null, done);
-  });
+	it('allows you to specify your own HTML template file', function(done) {
+		testHtmlPlugin({
+			entry: {
+				app: path.join(__dirname, 'fixtures/index.js')
+			},
+			output: {
+				path: OUTPUT_DIR,
+				filename: '[name]_bundle.js'
+			},
+			plugins: [new HtmlWebpackPlugin({
+				template: fs.readFileSync(path.join(__dirname, 'fixtures/test.html'))
+			})]
+		},
+		['<script src="app_bundle.js"', 'Some unique text'], null, done);
+	});
 
-  it('allows you to specify your own HTML template file', function(done) {
-    testHtmlPlugin({
-      entry: {
-        app: path.join(__dirname, 'fixtures/index.js')
-      },
-      output: {
-        path: OUTPUT_DIR,
-        filename: '[name]_bundle.js'
-      },
-      plugins: [new HtmlWebpackPlugin({template: path.join(__dirname, 'fixtures/test.html')})]
-    },
-    ['<script src="app_bundle.js"', 'Some unique text'], null, done);
-  });
+	it('allows you to specify your own HTML template string', function(done) {
+		testHtmlPlugin({
+			entry: {app: path.join(__dirname, 'fixtures/index.js')},
+			output: {
+				path: OUTPUT_DIR,
+				filename: 'app_bundle.js'
+			},
+			plugins: [new HtmlWebpackPlugin({
+				templateContent: fs.readFileSync(path.join(__dirname, 'fixtures/test.html'), 'utf8')
+			})]
+		},
+		['<script src="app_bundle.js"'], null, done);
+	});
 
-  it('allows you to specify your own HTML template string', function(done) {
-    testHtmlPlugin({
-      entry: {app: path.join(__dirname, 'fixtures/index.js')},
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'app_bundle.js'
-      },
-      plugins: [new HtmlWebpackPlugin({
-        templateContent: fs.readFileSync(path.join(__dirname, 'fixtures/test.html'), 'utf8')
-      })]
-    },
-    ['<script src="app_bundle.js"'], null, done);
-  });
+	it('works with source maps', function(done) {
+		testHtmlPlugin({
+			devtool: 'sourcemap',
+			entry: path.join(__dirname, 'fixtures/index.js'),
+			output: {
+				path: OUTPUT_DIR,
+				filename: 'index_bundle.js'
+			},
+			plugins: [new HtmlWebpackPlugin()]
+		}, ['<script src="index_bundle.js"'], null, done);
+	});
 
-  it('registers a webpack error both template and template content are specified', function(done) {
-    webpack({
-      entry: path.join(__dirname, 'fixtures/index.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'index_bundle.js'
-      },
-      plugins: [new HtmlWebpackPlugin({
-        template: path.join(__dirname, 'fixtures/test.html'),
-        templateContent: 'whatever'
-      })]
-    }, function(err, stats) {
-      expect(stats.hasErrors()).toBe(true);
-      expect(stats.toJson().errors[0]).toContain('HtmlWebpackPlugin');
-      done();
-    });
-  });
+	it('handles hashes in bundle filenames', function(done) {
+		testHtmlPlugin({
+			entry: path.join(__dirname, 'fixtures/index.js'),
+			output: {
+				path: OUTPUT_DIR,
+				filename: 'index_bundle_[hash].js'
+			},
+			plugins: [new HtmlWebpackPlugin()]
+		}, [/<script src="index_bundle_[0-9a-f]+\.js"/], null, done);
+	});
 
-  it('works with source maps', function(done) {
-    testHtmlPlugin({
-      devtool: 'sourcemap',
-      entry: path.join(__dirname, 'fixtures/index.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'index_bundle.js'
-      },
-      plugins: [new HtmlWebpackPlugin()]
-    }, ['<script src="index_bundle.js"'], null, done);
-  });
+	it('prepends the webpack public path to script src', function(done) {
+		testHtmlPlugin({
+			entry: path.join(__dirname, 'fixtures/index.js'),
+			output: {
+				path: OUTPUT_DIR,
+				filename: 'index_bundle.js',
+				publicPath: 'http://cdn.example.com/assets/'
+			},
+			plugins: [new HtmlWebpackPlugin()]
+		}, ['<script src="http://cdn.example.com/assets/index_bundle.js"'], null, done);
+	});
 
-  it('handles hashes in bundle filenames', function(done) {
-    testHtmlPlugin({
-      entry: path.join(__dirname, 'fixtures/index.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'index_bundle_[hash].js'
-      },
-      plugins: [new HtmlWebpackPlugin()]
-    }, [/<script src="index_bundle_[0-9a-f]+\.js"/], null, done);
-  });
+	it('handles subdirectories in the webpack output bundles', function(done) {
+		testHtmlPlugin({
+			entry: path.join(__dirname, 'fixtures/index.js'),
+			output: {
+				path: OUTPUT_DIR,
+				filename: 'assets/index_bundle.js'
+			},
+			plugins: [new HtmlWebpackPlugin()]
+		}, ['<script src="assets/index_bundle.js"'], null, done);
+	});
 
-  it('prepends the webpack public path to script src', function(done) {
-    testHtmlPlugin({
-      entry: path.join(__dirname, 'fixtures/index.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'index_bundle.js',
-        publicPath: 'http://cdn.example.com/assets/'
-      },
-      plugins: [new HtmlWebpackPlugin()]
-    }, ['<script src="http://cdn.example.com/assets/index_bundle.js"'], null, done);
-  });
+	it('handles subdirectories in the webpack output bundles along with a public path', function(done) {
+		testHtmlPlugin({
+			entry: path.join(__dirname, 'fixtures/index.js'),
+			output: {
+				path: OUTPUT_DIR,
+				filename: 'assets/index_bundle.js',
+				publicPath: 'http://cdn.example.com/'
+			},
+			plugins: [new HtmlWebpackPlugin()]
+		}, ['<script src="http://cdn.example.com/assets/index_bundle.js"'], null, done);
+	});
 
-  it('handles subdirectories in the webpack output bundles', function(done) {
-    testHtmlPlugin({
-      entry: path.join(__dirname, 'fixtures/index.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'assets/index_bundle.js'
-      },
-      plugins: [new HtmlWebpackPlugin()]
-    }, ['<script src="assets/index_bundle.js"'], null, done);
-  });
+	it('allows you to configure the title of the generated HTML page', function(done) {
+		testHtmlPlugin({
+			entry: path.join(__dirname, 'fixtures/index.js'),
+			output: {
+				path: OUTPUT_DIR,
+				filename: 'index_bundle.js'
+			},
+			plugins: [new HtmlWebpackPlugin({title: 'My Cool App'})]
+		}, ['<title>My Cool App</title>'], null, done);
+	});
 
-  it('handles subdirectories in the webpack output bundles along with a public path', function(done) {
-    testHtmlPlugin({
-      entry: path.join(__dirname, 'fixtures/index.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'assets/index_bundle.js',
-        publicPath: 'http://cdn.example.com/'
-      },
-      plugins: [new HtmlWebpackPlugin()]
-    }, ['<script src="http://cdn.example.com/assets/index_bundle.js"'], null, done);
-  });
+	it('allows you to configure the output filename', function(done) {
+		testHtmlPlugin({
+			entry: path.join(__dirname, 'fixtures/index.js'),
+			output: {
+				path: OUTPUT_DIR,
+				filename: 'index_bundle.js'
+			},
+			plugins: [new HtmlWebpackPlugin({filename: 'test.html'})]
+		}, ['<script src="index_bundle.js"'], 'test.html', done);
+	});
 
-  it('allows you to configure the title of the generated HTML page', function(done) {
-    testHtmlPlugin({
-      entry: path.join(__dirname, 'fixtures/index.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'index_bundle.js'
-      },
-      plugins: [new HtmlWebpackPlugin({title: 'My Cool App'})]
-    }, ['<title>My Cool App</title>'], null, done);
-  });
+	it('allows you to configure the output filename with a path', function(done) {
+		testHtmlPlugin({
+			entry: path.join(__dirname, 'fixtures/index.js'),
+			output: {
+				path: OUTPUT_DIR,
+				filename: 'index_bundle.js'
+			},
+			plugins: [new HtmlWebpackPlugin({filename: 'assets/test.html'})]
+		}, ['<script src="index_bundle.js"'], 'assets/test.html', done);
+	});
 
-  it('allows you to configure the output filename', function(done) {
-    testHtmlPlugin({
-      entry: path.join(__dirname, 'fixtures/index.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'index_bundle.js'
-      },
-      plugins: [new HtmlWebpackPlugin({filename: 'test.html'})]
-    }, ['<script src="index_bundle.js"'], 'test.html', done);
-  });
+	it('allows you write multiple HTML files', function(done) {
+		testHtmlPlugin({
+			entry: path.join(__dirname, 'fixtures/index.js'),
+			output: {
+				path: OUTPUT_DIR,
+				filename: 'index_bundle.js'
+			},
+			plugins: [
+				new HtmlWebpackPlugin(),
+				new HtmlWebpackPlugin({
+					filename: 'test.html',
+					template: path.join(__dirname, 'fixtures/test.html')
+				})
+			]
+		}, ['<script src="index_bundle.js"'], null, done);
 
-  it('allows you to configure the output filename with a path', function(done) {
-    testHtmlPlugin({
-      entry: path.join(__dirname, 'fixtures/index.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'index_bundle.js'
-      },
-      plugins: [new HtmlWebpackPlugin({filename: 'assets/test.html'})]
-    }, ['<script src="index_bundle.js"'], 'assets/test.html', done);
-  });
+		expect(fs.existsSync(path.join(__dirname, 'fixtures/test.html'))).toBe(true);
+	});
 
-  it('allows you write multiple HTML files', function(done) {
-    testHtmlPlugin({
-      entry: path.join(__dirname, 'fixtures/index.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'index_bundle.js'
-      },
-      plugins: [
-        new HtmlWebpackPlugin(),
-        new HtmlWebpackPlugin({
-          filename: 'test.html',
-          template: path.join(__dirname, 'fixtures/test.html')
-        })
-      ]
-    }, ['<script src="index_bundle.js"'], null, done);
-
-    expect(fs.existsSync(path.join(__dirname, 'fixtures/test.html'))).toBe(true);
-  });
-
-  it('registers a webpack error if the template cannot be opened', function(done) {
-    webpack({
-      entry: path.join(__dirname, 'fixtures/index.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'index_bundle.js'
-      },
-      plugins: [new HtmlWebpackPlugin({template: 'fixtures/does_not_exist.html'})]
-    }, function(err, stats) {
-      expect(stats.hasErrors()).toBe(true);
-      expect(stats.toJson().errors[0]).toContain('HtmlWebpackPlugin');
-      done();
-    });
-  });
+	it('should work with common chunks', function(done) {
+		testHtmlPlugin({
+			entry: {
+				util: path.join(__dirname, 'fixtures/util.js'),
+				app: path.join(__dirname, 'fixtures/index.js'),
+				pop: path.join(__dirname, 'fixtures/util.js')
+			},
+			output: {
+				path: OUTPUT_DIR,
+				filename: '[name]_bundle.js'
+			},
+			plugins: [
+				new webpack.optimize.CommonsChunkPlugin('util', '[name]_bundle.js'),
+				new HtmlWebpackPlugin()
+			]
+		}, ['<script src="util_bundle.js"', '<script src="app_bundle.js"'], null, done);
+	});
 
 });

--- a/spec/fixtures/index.js
+++ b/spec/fixtures/index.js
@@ -1,1 +1,2 @@
-document.body.innerHTML = document.body.innerHTML + "<p>index.js</p>";
+/*global document*/
+document.body.innerHTML = document.body.innerHTML + '<p>index.js</p>';

--- a/spec/fixtures/test.html
+++ b/spec/fixtures/test.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <p>Some unique text</p>
-    <script src="{%=o.htmlWebpackPlugin.assets.app%}"></script>
+    <script src="<%=assets.app%>"></script>
   </body>
 </html>

--- a/spec/fixtures/util.js
+++ b/spec/fixtures/util.js
@@ -1,1 +1,2 @@
-document.body.innerHTML = document.body.innerHTML + "<p>util.js</p>";
+/*global document*/
+document.body.innerHTML = document.body.innerHTML + '<p>util.js</p>';


### PR DESCRIPTION
 * 100% code coverage with `instanbul`,
 * Continuous integration with `travisci`,
 * Support for common chunks (https://github.com/ampedandwired/html-webpack-plugin/issues/4),
 * Support for externals,
 * Use more standard underscore/lo-dash templates,
 * More aggressive lint checking with `eslint`,
 * EditorConfig support,
 * Updated code documentation,
 * Automatic `publicPath` support (https://github.com/ampedandwired/html-webpack-plugin/issues/9),
 * Updated README.

This is obviously API incompatible, so in the spirit of cleanliness the template parameters and options have been cleaned up too. Version bump included for good measure.

Could still use some work. Pretty much all the existing tests pass with very minimal changes, if any.