### PR TITLE
Feature/append

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ plugins: [
 ]
 ```
 
-The `templateContent` option can also be a function:
+The `templateContent` option can also be a function to use another template language like jade:
 ```javascript
 plugins: [
   new HtmlWebpackPlugin({
@@ -206,3 +206,28 @@ template is rendered. This variable has the following attributes:
 
 - `webpackConfig`: the webpack configuration that was used for this compilation. This
   can be used, for example, to get the `publicPath` (`webpackConfig.output.publicPath`).
+
+
+Filtering chunks
+----------------
+
+To include only certain chunks you can limit the chunks beeing used:
+
+```javascript
+plugins: [
+  new HtmlWebpackPlugin({
+    chunks: ['app']
+  })
+]
+```
+
+It is also possible to exclude certain chunks by setting the `excludeChunks` option:
+
+```javascript
+plugins: [
+  new HtmlWebpackPlugin({
+    excludeChunks: ['dev-helper']
+  })
+]
+```
+

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ template is rendered. This variable has the following attributes:
 Filtering chunks
 ----------------
 
-To include only certain chunks you can limit the chunks beeing used:
+To include only certain chunks you can limit the chunks being used:
 
 ```javascript
 plugins: [

--- a/default_inject_index.html
+++ b/default_inject_index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>{%=o.htmlWebpackPlugin.options.title || 'Webpack App'%}</title>
+  </head>
+  <body>
+  </body>
+</html>

--- a/index.js
+++ b/index.js
@@ -149,11 +149,11 @@ HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function(html, templateParams
   });
   // Turn script files into script tags
   scripts = scripts.map(function(scriptPath) {
-    return '<script src="' + scriptPath + '?' + templateParams.hash + '"></script>';
+    return '<script src="' + scriptPath + templateParams.htmlWebpackPlugin.querystring + '"></script>';
   });
   // Turn css files into link tags
   styles = styles.map(function(stylePath) {
-    return '<link href="' + stylePath + '?' + templateParams.hash + '" rel="stylesheet">';
+    return '<link href="' + stylePath + templateParams.htmlWebpackPlugin.querystring + '" rel="stylesheet">';
   });
   // Append scripts to body element
   html = html.replace(/(<\/body>)/i, function (match) {
@@ -170,7 +170,7 @@ HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function(html, templateParams
       if (match.test(/\smanifest\s*=/)) {
         return match;
       }
-      return start + ' manifest="' + assets.manifest + '?' + templateParams.hash + '"' + end;
+      return start + ' manifest="' + assets.manifest + templateParams.htmlWebpackPlugin.querystring + '"' + end;
     });
   }
   return html;

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
     assets.chunks[chunkName] = {};
 
     // Prepend the public path to all chunk files
-    var chunkFiles = [].concat(webpackStatsJson.assetsByChunkName[chunkName]).map(function(chunkFile) {
+    var chunkFiles = [].concat(chunk.files).map(function(chunkFile) {
       return publicPath + chunkFile;
     });
 

--- a/index.js
+++ b/index.js
@@ -111,7 +111,9 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
 
     // Gather all css files
     var css = chunkFiles.filter(function(chunkFile){
-      return path.extname(chunkFile) === '.css';
+      // Some chunks may contain content hash in their names, for ex. 'main.css?1e7cac4e4d8b52fd5ccd2541146ef03f'.
+      // We must proper handle such cases, so we use regexp testing here
+      return /^.css/.test(path.extname(chunkFile));
     });
     assets.chunks[chunkName].css = css;
     assets.css = assets.css.concat(css);

--- a/index.js
+++ b/index.js
@@ -108,6 +108,13 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
       return publicPath + chunkFile + queryString;
     });
 
+    // Append a hash for cache busting
+    if (this.options.hash) {
+      chunkFiles = chunkFiles.map(function(chunkFile) {
+        return chunkFile + (chunkFile.indexOf('?') === -1 ? '?' : '&') + webpackStatsJson.hash;
+      });
+    }
+
     // Webpack outputs an array for each chunk when using sourcemaps
     // But we need only the entry file
     var entry = chunkFiles[0];
@@ -118,7 +125,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
     var css = chunkFiles.filter(function(chunkFile){
       // Some chunks may contain content hash in their names, for ex. 'main.css?1e7cac4e4d8b52fd5ccd2541146ef03f'.
       // We must proper handle such cases, so we use regexp testing here
-      return /^.css/.test(path.extname(chunkFile));
+      return /^.css($|\?)/.test(path.extname(chunkFile));
     });
     assets.chunks[chunkName].css = css;
     assets.css = assets.css.concat(css);
@@ -149,11 +156,11 @@ HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function(html, templateParams
   });
   // Turn script files into script tags
   scripts = scripts.map(function(scriptPath) {
-    return '<script src="' + scriptPath + templateParams.htmlWebpackPlugin.querystring + '"></script>';
+    return '<script src="' + scriptPath + '"></script>';
   });
   // Turn css files into link tags
   styles = styles.map(function(stylePath) {
-    return '<link href="' + stylePath + templateParams.htmlWebpackPlugin.querystring + '" rel="stylesheet">';
+    return '<link href="' + stylePath + '" rel="stylesheet">';
   });
   // Append scripts to body element
   html = html.replace(/(<\/body>)/i, function (match) {
@@ -170,7 +177,7 @@ HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function(html, templateParams
       if (match.test(/\smanifest\s*=/)) {
         return match;
       }
-      return start + ' manifest="' + assets.manifest + templateParams.htmlWebpackPlugin.querystring + '"' + end;
+      return start + ' manifest="' + assets.manifest + '"' + end;
     });
   }
   return html;

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ HtmlWebpackPlugin.prototype.emitHtml = function(compilation, htmlTemplateContent
 
 
 HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webpackStatsJson, includedChunks, excludedChunks) {
+  var self = this;
   var publicPath = compilation.options.output.publicPath || '';
 
   var assets = {
@@ -86,6 +87,11 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
       return path.extname(assetFile) === '.appcache';
     })[0]
   };
+
+  // Append a hash for cache busting
+  if (this.options.hash) {
+    assets.manifest = self.appendHash(assets.manifest, webpackStatsJson.hash);
+  }
 
   var chunks = webpackStatsJson.chunks.sort(function orderEntryLast(a, b) {
     if (a.entry !== b.entry) {
@@ -118,7 +124,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
     // Append a hash for cache busting
     if (this.options.hash) {
       chunkFiles = chunkFiles.map(function(chunkFile) {
-        return chunkFile + (chunkFile.indexOf('?') === -1 ? '?' : '&') + webpackStatsJson.hash;
+        return self.appendHash(chunkFile, webpackStatsJson.hash);
       });
     }
 
@@ -200,6 +206,15 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginLegacyAssets = function(compilation
   return legacyAssets;
 };
 
+/**
+ * Appends a cache busting hash
+ */
+HtmlWebpackPlugin.prototype.appendHash = function (url, hash) {
+  if (!url) {
+    return url;
+  }
+  return url + (url.indexOf('?') === -1 ? '?' : '&') + hash;
+};
 
 
 module.exports = HtmlWebpackPlugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-webpack-plugin",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Simplifies creation of HTML files to serve your webpack bundles",
   "main": "index.js",
   "scripts": {

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -97,7 +97,7 @@ describe('HtmlWebpackPlugin', function() {
       },
       plugins: [new HtmlWebpackPlugin({
         append: true,
-        template: path.join(__dirname, 'fixtures/test.html')
+        template: path.join(__dirname, 'fixtures/plain.html')
       })]
     }, ['<script src="util_bundle.js?%hash%"', '<script src="app_bundle.js?%hash%"'], null, done);
   });
@@ -114,7 +114,7 @@ describe('HtmlWebpackPlugin', function() {
       },
       plugins: [new HtmlWebpackPlugin({
         append: ['util', 'app'],
-        templateContent: fs.readFileSync(path.join(__dirname, 'fixtures/test.html'), 'utf8')
+        templateContent: fs.readFileSync(path.join(__dirname, 'fixtures/plain.html'), 'utf8')
       })]
     }, ['<script src="util_bundle.js?%hash%"', '<script src="app_bundle.js?%hash%"'], null, done);
   });
@@ -131,7 +131,7 @@ describe('HtmlWebpackPlugin', function() {
       },
       plugins: [new HtmlWebpackPlugin({
         append: ['app'],
-        template: path.join(__dirname, 'fixtures/test.html')
+        template: path.join(__dirname, 'fixtures/plain.html')
       })]
     }, ['<script src="app_bundle.js?%hash%"'], null, done);
   });

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -113,7 +113,8 @@ describe('HtmlWebpackPlugin', function() {
         filename: '[name]_bundle.js'
       },
       plugins: [new HtmlWebpackPlugin({
-        inject: ['util', 'app'],
+        inject: true,
+        chunks: ['util', 'app'],
         templateContent: fs.readFileSync(path.join(__dirname, 'fixtures/plain.html'), 'utf8')
       })]
     }, ['<script src="util_bundle.js"', '<script src="app_bundle.js"'], null, done);
@@ -130,7 +131,26 @@ describe('HtmlWebpackPlugin', function() {
         filename: '[name]_bundle.js'
       },
       plugins: [new HtmlWebpackPlugin({
-        inject: ['app'],
+        inject: true,
+        chunks: ['app'],
+        template: path.join(__dirname, 'fixtures/plain.html')
+      })]
+    }, ['<script src="app_bundle.js"'], null, done);
+  });
+
+  it('allows you to inject a specified asset into a given html file', function (done) {
+    testHtmlPlugin({
+      entry: {
+        util: path.join(__dirname, 'fixtures/util.js'),
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        inject: true,
+        excludeChunks: ['util'],
         template: path.join(__dirname, 'fixtures/plain.html')
       })]
     }, ['<script src="app_bundle.js"'], null, done);

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -85,7 +85,7 @@ describe('HtmlWebpackPlugin', function() {
     ['<script src="app_bundle.js'], null, done);
   });
 
-  it('allows you to append the assets to a given html file', function (done) {
+  it('allows you to inject the assets into a given html file', function (done) {
     testHtmlPlugin({
       entry: {
         util: path.join(__dirname, 'fixtures/util.js'),
@@ -96,13 +96,13 @@ describe('HtmlWebpackPlugin', function() {
         filename: '[name]_bundle.js'
       },
       plugins: [new HtmlWebpackPlugin({
-        append: true,
+        inject: true,
         template: path.join(__dirname, 'fixtures/plain.html')
       })]
     }, ['<script src="util_bundle.js?%hash%"', '<script src="app_bundle.js?%hash%"'], null, done);
   });
 
-  it('allows you to append the assets to a html string', function (done) {
+  it('allows you to inject the assets into a html string', function (done) {
     testHtmlPlugin({
       entry: {
         util: path.join(__dirname, 'fixtures/util.js'),
@@ -113,13 +113,13 @@ describe('HtmlWebpackPlugin', function() {
         filename: '[name]_bundle.js'
       },
       plugins: [new HtmlWebpackPlugin({
-        append: ['util', 'app'],
+        inject: ['util', 'app'],
         templateContent: fs.readFileSync(path.join(__dirname, 'fixtures/plain.html'), 'utf8')
       })]
     }, ['<script src="util_bundle.js?%hash%"', '<script src="app_bundle.js?%hash%"'], null, done);
   });
 
-  it('allows you to append a specified asset to a given html file', function (done) {
+  it('allows you to inject a specified asset into a given html file', function (done) {
     testHtmlPlugin({
       entry: {
         util: path.join(__dirname, 'fixtures/util.js'),
@@ -130,7 +130,7 @@ describe('HtmlWebpackPlugin', function() {
         filename: '[name]_bundle.js'
       },
       plugins: [new HtmlWebpackPlugin({
-        append: ['app'],
+        inject: ['app'],
         template: path.join(__dirname, 'fixtures/plain.html')
       })]
     }, ['<script src="app_bundle.js?%hash%"'], null, done);

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -85,6 +85,57 @@ describe('HtmlWebpackPlugin', function() {
     ['<script src="app_bundle.js'], null, done);
   });
 
+  it('allows you to append the assets to a given html file', function (done) {
+    testHtmlPlugin({
+      entry: {
+        util: path.join(__dirname, 'fixtures/util.js'),
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        append: true,
+        template: path.join(__dirname, 'fixtures/test.html')
+      })]
+    }, ['<script src="util_bundle.js?%hash%"', '<script src="app_bundle.js?%hash%"'], null, done);
+  });
+
+  it('allows you to append the assets to a html string', function (done) {
+    testHtmlPlugin({
+      entry: {
+        util: path.join(__dirname, 'fixtures/util.js'),
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        append: ['util', 'app'],
+        templateContent: fs.readFileSync(path.join(__dirname, 'fixtures/test.html'), 'utf8')
+      })]
+    }, ['<script src="util_bundle.js?%hash%"', '<script src="app_bundle.js?%hash%"'], null, done);
+  });
+
+  it('allows you to append a specified asset to a given html file', function (done) {
+    testHtmlPlugin({
+      entry: {
+        util: path.join(__dirname, 'fixtures/util.js'),
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        append: ['app'],
+        template: path.join(__dirname, 'fixtures/test.html')
+      })]
+    }, ['<script src="app_bundle.js?%hash%"'], null, done);
+  });
+
   it('allows you to use the deprecated assets object', function (done) {
     testHtmlPlugin({
         entry: {

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -99,7 +99,7 @@ describe('HtmlWebpackPlugin', function() {
         inject: true,
         template: path.join(__dirname, 'fixtures/plain.html')
       })]
-    }, ['<script src="util_bundle.js?%hash%"', '<script src="app_bundle.js?%hash%"'], null, done);
+    }, ['<script src="util_bundle.js"', '<script src="app_bundle.js"'], null, done);
   });
 
   it('allows you to inject the assets into a html string', function (done) {
@@ -116,7 +116,7 @@ describe('HtmlWebpackPlugin', function() {
         inject: ['util', 'app'],
         templateContent: fs.readFileSync(path.join(__dirname, 'fixtures/plain.html'), 'utf8')
       })]
-    }, ['<script src="util_bundle.js?%hash%"', '<script src="app_bundle.js?%hash%"'], null, done);
+    }, ['<script src="util_bundle.js"', '<script src="app_bundle.js"'], null, done);
   });
 
   it('allows you to inject a specified asset into a given html file', function (done) {
@@ -133,7 +133,7 @@ describe('HtmlWebpackPlugin', function() {
         inject: ['app'],
         template: path.join(__dirname, 'fixtures/plain.html')
       })]
-    }, ['<script src="app_bundle.js?%hash%"'], null, done);
+    }, ['<script src="app_bundle.js"'], null, done);
   });
 
   it('allows you to use the deprecated assets object', function (done) {
@@ -229,6 +229,17 @@ describe('HtmlWebpackPlugin', function() {
         filename: 'index_bundle.js'
       },
       plugins: [new HtmlWebpackPlugin({hash: true})]
+    }, ['<script src="index_bundle.js?%hash%"'], null, done);
+  });
+
+  it('allows to append hashes to the assets', function(done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({hash: true, inject: true})]
     }, ['<script src="index_bundle.js?%hash%"'], null, done);
   });
 

--- a/spec/fixtures/plain.html
+++ b/spec/fixtures/plain.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Example Plain file</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
This pull requests is build on top of #14 and fixes #12.
Unfortunately it is hard to review as it shows all changes from (#14) as well.
[This commit contains only the changes of this PR](https://github.com/jantimon/html-webpack-plugin/commit/fd47eda875a643a78c362b27cae5f1065fb18a94)

The new code allows to pass a plain html file like [this one](https://github.com/ampedandwired/html-webpack-plugin/blob/fd47eda875a643a78c362b27cae5f1065fb18a94/spec/fixtures/plain.html) and injects all chunks or only the given chunks.

Usage:

```js
new HtmlWebpackPlugin({
       append: true,
       template: path.join(__dirname, 'fixtures/test.html')
     })
```

If append is not set or `false` the HtmlWebpackPlugin will work just like before.