### PR TITLE
Added support for minification using html-minifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,11 @@ HtmlWebpackPlugin.prototype.emitHtml = function(compilation, htmlTemplateContent
   if (this.options.inject) {
     html = this.injectAssetsIntoHtml(html, templateParams);
   }
+  if (templateParams.htmlWebpackPlugin.options.minify) {
+    var minify = require('html-minifier').minify;
+    var minify_options = templateParams.htmlWebpackPlugin.options.minify.constructor === Object ? templateParams.htmlWebpackPlugin.options.minify : {};
+    html = minify(html, minify_options);
+  }
   compilation.assets[outputFilename] = {
     source: function() {
       return html;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "blueimp-tmpl": "~2.5.4",
+    "html-minifier": "^0.7.1",
     "lodash": "~3.6.0"
   }
 }


### PR DESCRIPTION
I discovered ```html-webpack-plugin``` today, great tool, thanks.

This PR adds a ```minify``` option (```true``` or an options ```object```), which enables the minification of all resulting HTML files, using [kangax/html-minifier](https://github.com/kangax/html-minifier). This comes handy when you are working on your own (unminified) template file, but want the smallest final output for performance.

Please note that ```html-minifier``` is very conservative by default, as most of [its options](https://github.com/kangax/html-minifier#options-quick-reference) are set to ```false```.
I suggest using these for example:
```
  var HtmlWebpackPlugin = require('html-webpack-plugin');
  var html_webpack_options = {
    template: 'src/assets/index.template.html'
  };
  if (production) {
    html_webpack_options.minify = {
      removeComments: true,
      collapseWhitespace: true,
      conservativeCollapse: true,
      minifyJS: true,
      minifyCSS: true
    };
  }
  config.plugins.push(new HtmlWebpackPlugin(html_webpack_options));
```
Hope this helps.