### PR TITLE
Fixed gathering CSS chunks with content hash in their names

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,9 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
 
     // Gather all css files
     var css = chunkFiles.filter(function(chunkFile){
-      return path.extname(chunkFile) === '.css';
+      // Some chunks may contain content hash in their names, for ex. 'main.css?1e7cac4e4d8b52fd5ccd2541146ef03f'.
+      // We must proper handle such cases, so we use regexp testing here
+      return /^.css/.test(path.extname(chunkFile));
     });
     assets.chunks[chunk].css = css;
     assets.css = assets.css.concat(css);


### PR DESCRIPTION
This change allows to properly populate default_index with links to css files which contains content hash in their names. For example, when we create separated stylesheets with ExtractTextPlugin:

new ExtractTextPlugin("[name].css?[contenthash]");

Currently html-webpack-plugin will not include such files in generated index.html.