### PR TITLE
Use files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.3.0",
   "description": "Simplifies creation of HTML files to serve your webpack bundles",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "default_index.html",
+    "default_inject_index.html"
+  ],
   "scripts": {
     "test": "jshint -c .jshintrc *.js spec && jasmine-node --captureExceptions spec"
   },


### PR DESCRIPTION
Reduces the number of file a consumer gets when `npm install`ing this package.

Before: http://hastebin.com/kafifaxeqe.sh
After: http://hastebin.com/yejasupoqe.sh