### PR TITLE
Fixes error reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ HtmlWebpackPlugin.prototype.apply = function(compiler) {
         var assets = self.htmlWebpackPluginLegacyAssets(compilation, webpackStatsJson);
         Object.defineProperty(templateParams.htmlWebpackPlugin, 'assets', {
           get: function() {
-            compilation.errors.push('htmlWebpackPlugin.assets is deprecated - please use htmlWebpackPlugin.files instead');
+            compilation.errors.push(new Error('HtmlWebPackPlugin: htmlWebpackPlugin.assets is deprecated - please use htmlWebpackPlugin.files instead'));
             return assets;
           }
         });


### PR DESCRIPTION
Fixes error reporting so that instead of:

Error in undefined

We get:

Error in HtmlWebPackPlugin: htmlWebpackPlugin.assets is deprecated - please use htmlWebpackPlugin.files instead