### PR TITLE
[chunk] fix the case where the name is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,6 +206,11 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
     var chunk = chunks[i];
     var chunkName = chunk.names[0];
 
+    // This chunk doesn't have a name. This script can't handled it.
+    if (chunkName === undefined) {
+      continue;
+    }
+
     // Skip if the chunks should be filtered and the given chunk was not added explicity
     if (Array.isArray(includedChunks) && includedChunks.indexOf(chunkName) === -1) {
       continue;


### PR DESCRIPTION
Let's say we have 3 chunks with an undefined name. The last one will be included in the index.html whereas none should be included.
Maybe, we should assert that the field entry of the chuck is true at the beginning.