### PR TITLE
Adding the file size to the chunk object

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,6 +245,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
     // Webpack outputs an array for each chunk when using sourcemaps
     // But we need only the entry file
     var entry = chunkFiles[0];
+    assets.chunks[chunkName].size = chunk.size;
     assets.chunks[chunkName].entry = entry;
     assets.js.push(entry);
 


### PR DESCRIPTION
As far as I know, getting the file size within the template is not possible.

I added a way to get it like this: ``` {%=o.htmlWebpackPlugin.files.chunks.main.size %}```

The file size is important in my case in order to have a progress loader via http request so I can do something like that:

```
function ajax(url, onProgress, callback, data, x) {
            try {
                x = new(this.XMLHttpRequest || ActiveXObject)('MSXML2.XMLHTTP.3.0');
                x.open(data ? 'POST' : 'GET', url, 1);
                x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
                x.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
                x.onreadystatechange = function() {
                    x.readyState > 3 && callback && callback(x.responseText, x);
                };
                x.addEventListener("progress", onProgress, false);
                x.send(data)
            } catch (e) {
                window.console && console.log(e);
            }
        };

        function onLoad(responseText) {
            var script = document.createElement('script');
            script.setAttribute('type', 'text/javascript');
            if (script.text) {
                script.text = content; // IE
            } else {
                script.appendChild(document.createTextNode(responseText));
            }
            document.getElementsByTagName('head')[0].appendChild(script);
            document.getElementById('appLoader').className = 'finished';
        }

        function onProgress(e) {
            var progress = Math.floor((e.loaded / {%=o.htmlWebpackPlugin.files.chunks.main.size %} || 0) * 100);
            document.getElementById('appLoader').setAttribute("value", progress);
            document.getElementById('appLoaderPercent').innerText = document.createTextNode(progress).textContent;
        }

        ajax('./{%=o.htmlWebpackPlugin.files.chunks.main.entry %}', onProgress, onLoad);
```