### PR TITLE
Bump project dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,20 +29,20 @@
   },
   "homepage": "https://github.com/ampedandwired/html-webpack-plugin",
   "devDependencies": {
-    "css-loader": "^0.12.0",
-    "extract-text-webpack-plugin": "^0.7.1",
-    "file-loader": "^0.8.1",
-    "jasmine-node": "^1.14.5",
-    "jshint": "^2.7.0",
-    "rimraf": "^2.3.3",
-    "style-loader": "^0.12.2",
-    "url-loader": "^0.5.5",
-    "webpack": "^1.8.11"
+    "css-loader": "^0.15.4",
+    "extract-text-webpack-plugin": "^0.8.2",
+    "file-loader": "^0.8.4",
+    "jasmine-node": "^2.0.0",
+    "jshint": "^2.8.0",
+    "rimraf": "^2.4.1",
+    "style-loader": "^0.12.3",
+    "url-loader": "^0.5.6",
+    "webpack": "^1.10.1"
   },
   "dependencies": {
-    "bluebird": "^2.9.25",
-    "blueimp-tmpl": "~2.5.4",
+    "bluebird": "^2.9.34",
+    "blueimp-tmpl": "^2.5.4",
     "html-minifier": "^0.7.2",
-    "lodash": "~3.9.3"
+    "lodash": "^3.10.0"
   }
 }


### PR DESCRIPTION
Lodash being on 3.9.3 is killing 'npm shrinkwrap' in one of my current projects. On a not-so-personal note, who wouldn't want to have a green dependencies badge on her project page, right? ;)
Made sure tests still pass.
