### PR TITLE
Add support for webpack.BannerPlugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ HtmlWebpackPlugin.prototype.compileTemplate = function(template, outputFilename,
   childCompiler.apply(
     new NodeTemplatePlugin(outputOptions),
     new NodeTargetPlugin(),
-    new LibraryTemplatePlugin('result', 'var'),
+    new LibraryTemplatePlugin('HTML_WEBPACK_PLUGIN_RESULT', 'var'),
     new SingleEntryPlugin(this.context, template),
     new LoaderTargetPlugin('node'),
     new webpack.DefinePlugin({ HTML_WEBPACK_PLUGIN : 'true' })
@@ -186,14 +186,8 @@ HtmlWebpackPlugin.prototype.evaluateCompilationResult = function(compilation, co
     return Promise.reject('The child compilation didn\'t provide a result');
   }
   var source = compilationResult.source();
-  // Strip the leading 'var ' if present.
-  // If webpack.BannerPlugin is used, `source` starts with given comment.
-  if (_.startsWith(source, 'var')) {
-    source = source.substr(3);
-  } else {
-    // Replace first matching result variable, so that only a function is left.
-    source = source.replace('var result =', '');
-  }
+  // Replace first matching result variable, so that only a function is left.
+  source = source.replace('var HTML_WEBPACK_PLUGIN_RESULT =', '');
 
   // Evaluate code and cast to string
   var newSource;

--- a/index.js
+++ b/index.js
@@ -185,8 +185,16 @@ HtmlWebpackPlugin.prototype.evaluateCompilationResult = function(compilation, co
   if(!compilationResult) {
     return Promise.reject('The child compilation didn\'t provide a result');
   }
-  // Strip the leading 'var '
-  var source = compilationResult.source().substr(3);
+  var source = compilationResult.source();
+  // Strip the leading 'var ' if present.
+  // If webpack.BannerPlugin is used, `source` starts with given comment.
+  if (_.startsWith(source, 'var')) {
+    source = source.substr(3);
+  } else {
+    // Replace first matching result variable, so that only a function is left.
+    source = source.replace('var result =', '');
+  }
+
   // Evaluate code and cast to string
   var newSource;
   try {

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -627,6 +627,20 @@ describe('HtmlWebpackPlugin', function() {
     }, ['<html lang="en" manifest="foo.appcache">'], null, done);
   });
 
+  it('works with webpack bannerplugin', function(done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [
+        new webpack.BannerPlugin('Copyright and such.'),
+        new HtmlWebpackPlugin()
+      ]
+    }, ['<html'], null, done);
+  });
+
   it('shows an error when a template fails to load', function(done) {
     testHtmlPlugin({
       entry: path.join(__dirname, 'fixtures/index.js'),


### PR DESCRIPTION
Previously the first 3 characters were stripped from the beginning of the source; it assumed these characters are `var`. When using the webpack.BannerPlugin, the source starts with the given comment and after that `var result` is used. This is fixed now and I've added a test for this.

This may not be the most clean solution, but it works.