### PR TITLE
On Windows relative path doesn't work properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var fs = require('fs');
 var path = require('path');
+ var urlModule = require('url');
 var _ = require('lodash');
 var tmpl = require('blueimp-tmpl').tmpl;
 var Promise = require('bluebird');
@@ -101,6 +102,8 @@ HtmlWebpackPlugin.prototype.getTemplateContent = function(compilation, templateP
   if (!templateFile) {
     // Use a special index file to prevent double script / style injection if the `inject` option is truthy
     templateFile = path.join(__dirname, self.options.inject ? 'default_inject_index.html' : 'default_index.html');
+  } else {
+    templateFile = path.join(templateFile);
   }
   compilation.fileDependencies.push(templateFile);
   return fs.readFileAsync(templateFile, 'utf8')
@@ -176,7 +179,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
       path.relative(path.dirname(self.options.filename), '.');
 
   if (publicPath.length && publicPath.substr(-1, 1) !== '/') {
-    publicPath += '/';
+    publicPath = urlModule.resolve(publicPath + '/', '.') + '/';
   }
 
   var assets = {

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ HtmlWebpackPlugin.prototype.getTemplateContent = function(compilation, templateP
     // Use a special index file to prevent double script / style injection if the `inject` option is truthy
     templateFile = path.join(__dirname, self.options.inject ? 'default_inject_index.html' : 'default_index.html');
   } else {
-    templateFile = path.join(templateFile);
+    templateFile = path.normalize(templateFile);
   }
   compilation.fileDependencies.push(templateFile);
   return fs.readFileAsync(templateFile, 'utf8')

--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
       path.relative(path.dirname(self.options.filename), '.');
 
   if (publicPath.length && publicPath.substr(-1, 1) !== '/') {
-    publicPath = urlModule.resolve(publicPath + '/', '.') + '/';
+    publicPath = path.join(urlModule.resolve(publicPath + '/', '.'), '/');
   }
 
   var assets = {

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -114,6 +114,23 @@ describe('HtmlWebpackPlugin', function() {
     }, ['<script src="util_bundle.js"', '<script src="app_bundle.js"'], null, done);
   });
 
+  it('allows to specify windows/*nix paths to template', function (done) {
+    testHtmlPlugin({
+      entry: {
+        util: path.join(__dirname, 'fixtures/util.js'),
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        inject: true,
+        template: path.join(__dirname, 'fixtures') + '/plain.html'
+      })]
+    }, ['<script src="util_bundle.js"', '<script src="app_bundle.js"'], null, done);
+  });
+
   it('allows you to inject the assets into the body of the given template', function (done) {
     testHtmlPlugin({
       entry: {


### PR DESCRIPTION
There are two case my colleague ran into:
1. when we are using relative publicPath - it generates ```<script src='..\../main.js'>``` instead of safe web ```<script src='../../main.js'>```. In pull request I wrapped **publicPath** with **url.resolve**.
2. when in path to template we are using forward slashes on windows build breaks and index.html is not generated. In pull request i wrapped it with **path.normalize**.