### PR TITLE
inject reference feature added

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Allowed values are as follows:
    You can specify a subdirectory here too (eg: `assets/admin.html`).
 - `template`: A html template (supports [blueimp templates](https://github.com/blueimp/JavaScript-Templates)).
 - `templateContent`: A html string or a function returning the html  (supports [blueimp templates](https://github.com/blueimp/JavaScript-Templates)).  
-- `inject`: `true | 'head' | 'body' | false` Inject all assets into the given `template` or `templateContent` - When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element.
+- `inject`: `true | 'head' | 'body' | 'reference' | false` Inject all assets into the given `template` or `templateContent` - When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element. `'reference'` is looking for `<!-- webpack scripts here -->` block in the template and injects the script to its position.
 - `favicon`: Adds the given favicon path to the output html.
 - `minify`: `{...} | false` Pass a [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference) options object to minify the output.
 - `hash`: `true | false` if `true` then append a unique webpack compilation hash to all

--- a/index.js
+++ b/index.js
@@ -299,8 +299,14 @@ HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function(html, templateParams
   }
   // Add styles to the head
   head = head.concat(styles);
-  // Add scripts to body or head
-  if (this.options.inject === 'head') {
+  // Add scripts to body, head or referenced positions
+  if (this.options.inject === 'reference') {
+    // Append assets to referenced position
+    // Test regex here https://regex101.com/r/sV6bM4/1
+    html = html.replace(/(<!--\s*webpack\s*scripts\s*here\s*-->)/gmi, function () {
+      return scripts;
+    });
+  } else if (this.options.inject === 'head') {
     head = head.concat(scripts);
   } else {
     body = body.concat(scripts);

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -131,6 +131,23 @@ describe('HtmlWebpackPlugin', function() {
     }, ['<script src="util_bundle.js"', '<script src="app_bundle.js"'], null, done);
   });
 
+  it('allows you to inject the assets into the referenced position of the given template', function (done) {
+    testHtmlPlugin({
+      entry: {
+        util: path.join(__dirname, 'fixtures/util.js'),
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        inject: 'reference',
+        template: path.join(__dirname, 'fixtures/plain_referenced.html')
+      })]
+    }, ['<script src="util_bundle.js"', '<script src="app_bundle.js"'], null, done);
+  });
+
   it('allows you to inject the assets into the body of the given template', function (done) {
     testHtmlPlugin({
       entry: {

--- a/spec/fixtures/plain_referenced.html
+++ b/spec/fixtures/plain_referenced.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Example Plain file</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- webpack scripts here -->
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Added a feature to setup the injection position in the template (not always to the end of the body or head). This is useful when using async script loader like $script.js.