### PR TITLE
Fix publicPath for feature/loaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,7 +335,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, chun
       path.relative(path.dirname(self.options.filename), '.');
 
   if (publicPath.length && publicPath.substr(-1, 1) !== '/') {
-    publicPath = urlModule.resolve(publicPath, '.')  + '/';
+    publicPath = path.join(urlModule.resolve(publicPath + '/', '.'), '/');
   }
 
   var assets = {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var fs = require('fs');
 var _ = require('lodash');
 var Promise = require('bluebird');
 var path = require('path');
-var urlModule = require('url');
 Promise.promisifyAll(fs);
 
 var webpack = require('webpack');
@@ -335,7 +334,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, chun
       path.relative(path.dirname(self.options.filename), '.');
 
   if (publicPath.length && publicPath.substr(-1, 1) !== '/') {
-    publicPath = path.join(urlModule.resolve(publicPath + '/', '.'), '/');
+    publicPath += '/';
   }
 
   var assets = {


### PR DESCRIPTION
I've incorporated 396cdedf8a554465d00797bb4d279b085e2e05d8 into the `feature/loaders` branch, which should fix the failing tests for old Node.js versions.