### PR TITLE
FIX missing [hash] interpolation in publicPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
 
   // Use the configured public path or build a relative path
   var publicPath = typeof compilation.options.output.publicPath !== 'undefined' ?
-      compilation.options.output.publicPath :
+      compilation.mainTemplate.getPublicPath({hash: webpackStatsJson.hash}) :
       path.relative(path.dirname(self.options.filename), '.');
 
   if (publicPath.length && publicPath.substr(-1, 1) !== '/') {

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -304,6 +304,18 @@ describe('HtmlWebpackPlugin', function() {
     }, [/<script src="index_bundle_[0-9a-f]+\.js/], null, done);
   });
 
+  it('handles hashes in publicPath', function(done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js',
+        publicPath: 'assets/[hash]/'
+      },
+      plugins: [new HtmlWebpackPlugin()]
+    }, [/<script src="assets\/[0-9a-f]+\/index_bundle\.js/], null, done);
+  });
+
   it('allows to append hashes to the assets', function(done) {
     testHtmlPlugin({
       entry: path.join(__dirname, 'fixtures/index.js'),


### PR DESCRIPTION
Webpack gives the possibility to use the build [hash] in
output.publicPath option:
https://webpack.github.io/docs/long-term-caching.html

However HtmlWebpackPlugin is reading directly the raw option, preventing the
user to use this option when using it.