### PR TITLE
Fix minify option

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,9 +259,9 @@ HtmlWebpackPlugin.prototype.postProcessHtml = function(html, assets) {
       if (self.options.minify) {
         var minify = require('html-minifier').minify;
         try {
-          return minify(html, this.options.minify);
+          return minify(html, self.options.minify);
         } catch(e) {
-          Promise.reject(e);
+          return Promise.reject(e);
         }
       }
       return html;

--- a/index.js
+++ b/index.js
@@ -258,12 +258,9 @@ HtmlWebpackPlugin.prototype.postProcessHtml = function(html, assets) {
     .then(function(html) {
       if (self.options.minify) {
         var minify = require('html-minifier').minify;
-        try {
-          return minify(html, self.options.minify);
-        } catch(e) {
-          return Promise.reject(e);
-        }
+        return minify(html, self.options.minify);
       }
+
       return html;
     });
 };


### PR DESCRIPTION
It used `this` instead of `self` and there was not errors because they there caught and not forwarded back to promise (forgotten `return` before `Promise.reject()`).

Btw, why need to `try..catch` if you are already in `Promise`, shouldn't it be auto-rejected on error?