### PR TITLE
Add a body template parameter to the default template

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ You can pass a hash of configuration options to `HtmlWebpackPlugin`.
 Allowed values are as follows:
 
 - `title`: The title to use for the generated HTML document.
+- `body`: Initial content for the generated HTML document's `<body>`.
 - `filename`: The file to write the HTML to. Defaults to `index.html`.
    You can specify a subdirectory here too (eg: `assets/admin.html`).
 - `template`: A html template (supports [blueimp templates](https://github.com/blueimp/JavaScript-Templates)).
@@ -91,6 +92,7 @@ Here's an example webpack config illustrating how to use these options:
   plugins: [
     new HtmlWebpackPlugin({
       title: 'My App',
+      body: '<div id="app"></div>',
       filename: 'assets/admin.html'
     })
   ]

--- a/default_index.html
+++ b/default_index.html
@@ -11,6 +11,7 @@
     {% } %}
   </head>
   <body>
+    {%#o.htmlWebpackPlugin.options.body%}
     {% for (var chunk in o.htmlWebpackPlugin.files.chunks) { %}
     <script src="{%=o.htmlWebpackPlugin.files.chunks[chunk].entry %}"></script>
     {% } %}

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -464,6 +464,17 @@ describe('HtmlWebpackPlugin', function() {
     }, ['<title>My Cool App</title>'], null, done);
   });
 
+  it('allows you to configure initial body contents of the generated HTML page', function(done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({body: '<div id="app"></div>'})]
+    }, ['<div id="app"></div>'], null, done);
+  });
+
   it('allows you to configure the output filename', function(done) {
     testHtmlPlugin({
       entry: path.join(__dirname, 'fixtures/index.js'),


### PR DESCRIPTION
This makes it more convenient to add placeholder content or a render target in `<body>` while making use of everything else the default template provides and without having to define an entire custom template around it.