### PR TITLE
Turn off bluebird warnings for "runaway" promise.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ var path = require('path');
 var _ = require('lodash');
 var tmpl = require('blueimp-tmpl').tmpl;
 var Promise = require('bluebird');
+Promise.config({
+  // Disable warnings
+  warnings: false
+});
 Promise.promisifyAll(fs);
 
 function HtmlWebpackPlugin(options) {


### PR DESCRIPTION
The issue isn't causing any problems so I'm ok with just turning off the warning. This probably won't be a problem in V2 anyway.