### PR TITLE
Introduce injectDivWithId-option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Allowed values are as follows:
    You can specify a subdirectory here too (eg: `assets/admin.html`).
 - `template`: Path to the template. Supports loaders e.g. `html!./index.html`.
 - `inject`: `true | 'head' | 'body' | false` Inject all assets into the given `template` or `templateContent` - When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element.
+- `injectDivWithId`: `'some id' | false` Inject a `div` with the given `id` into the body of the document. Only works in conjunction with the `inject` option. This is useful for creating a container for React applications.
 - `favicon`: Adds the given favicon path to the output html.
 - `minify`: `{...} | false` Pass a [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference) options object to minify the output.
 - `hash`: `true | false` if `true` then append a unique webpack compilation hash to all

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function HtmlWebpackPlugin(options) {
     filename: 'index.html',
     hash: false,
     inject: true,
+    injectDivWithId: false,
     compile: true,
     favicon: false,
     minify: false,
@@ -296,7 +297,7 @@ HtmlWebpackPlugin.prototype.addFileToAssets = function(filename, compilation) {
  * Helper to sort chunks
  */
 HtmlWebpackPlugin.prototype.sortChunks = function(chunks, sortMode) {
-  // Sort mode auto by default: 
+  // Sort mode auto by default:
   if (typeof sortMode === 'undefined' || sortMode === 'auto') {
     return chunks.sort(function orderEntryLast(a, b) {
       if (a.entry !== b.entry) {
@@ -455,6 +456,10 @@ HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function(html, assets) {
     head = head.concat(scripts);
   } else {
     body = body.concat(scripts);
+  }
+  // Add a div with given ID to body
+  if (this.options.injectDivWithId) {
+    body.unshift('<div id="' + this.options.injectDivWithId + '"></div>');
   }
   // Append assets to head element
   html = html.replace(/(<\/head>)/i, function (match) {

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Workaround for css-loader issue 
+// Workaround for css-loader issue
 // https://github.com/webpack/css-loader/issues/144
 if (!global.Promise) {
   require('es6-promise').polyfill();
@@ -707,6 +707,21 @@ describe('HtmlWebpackPlugin', function() {
         })
       ]
     }, [/<script src="a_bundle.js">.+<script src="b_bundle.js">.+<script src="c_bundle.js">/], null, done);
+  });
+
+  it('should inject a div with a given ID', function(done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          injectDivWithId: 'container'
+        })
+      ]
+    }, ['<div id="container"></div>'], null, done);
   });
 
 });


### PR DESCRIPTION
The only reason we have our own template is to add a div to be used as container for our react app. This option allows us to avoid that.