### PR TITLE
Fixed broken output.publicPath when using url

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, webp
       path.relative(path.dirname(self.options.filename), '.');
 
   if (publicPath.length && publicPath.substr(-1, 1) !== '/') {
-    publicPath = path.join(urlModule.resolve(publicPath + '/', '.'), '/');
+    publicPath = urlModule.resolve(publicPath + '/', '.');
   }
 
   var assets = {


### PR DESCRIPTION
When using url to cdn in output.publicPath, as example - http://cdn.example.com - path.join replace two slash to one - http:/cdn.example.com, it's broken url, and resources don't load.