### PR TITLE
Support lodash template's HTML "escape" delimiter (<%- %>)

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function HtmlWebpackPlugin(options) {
     excludeChunks: [],
     title: 'Webpack App'
   }, options);
-  // If the template doesn't use a loader use the blueimp template loader
+  // If the template doesn't use a loader use the lodash template loader
   if(this.options.template.indexOf('!') === -1) {
     this.options.template = require.resolve('./loader.js') + '!' + path.resolve(this.options.template);
   }

--- a/loader.js
+++ b/loader.js
@@ -21,5 +21,5 @@ module.exports = function (source) {
   // Use underscore for a minimalistic loader
   var options = loaderUtils.parseQuery(this.query);
   var template = _.template(source, options);
-  return 'module.exports = ' + template;
+  return 'var _ = require("lodash"); module.exports = ' + template;
 };


### PR DESCRIPTION
Without this, it will throw `ERROR in Template execution failed: ReferenceError: _ is not defined` when use `<%- something %>` in template.
The template functions referenced `_.escape`, and it lost the reference when transform it to string.