### PR TITLE
support access compiled assets content

### DIFF
--- a/index.js
+++ b/index.js
@@ -370,7 +370,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, chun
     var chunkName = chunk.names[0];
 
     assets.chunks[chunkName] = {};
-    assets.chunks[chunkName].source = compilation.assets[chunk.files[0]].source.bind(compilation.assets[chunk.files[0]])
+    assets.chunks[chunkName].source = compilation.assets[chunk.files[0]].source.bind(compilation.assets[chunk.files[0]]);
 
     // Prepend the public path to all chunk files
     var chunkFiles = [].concat(chunk.files).map(function(chunkFile) {

--- a/index.js
+++ b/index.js
@@ -370,6 +370,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function(compilation, chun
     var chunkName = chunk.names[0];
 
     assets.chunks[chunkName] = {};
+    assets.chunks[chunkName].source = compilation.assets[chunk.files[0]].source.bind(compilation.assets[chunk.files[0]])
 
     // Prepend the public path to all chunk files
     var chunkFiles = [].concat(chunk.files).map(function(chunkFile) {

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -889,4 +889,18 @@ describe('HtmlWebpackPlugin', function() {
     }, [/<script src="a_bundle.js">.+<script src="b_bundle.js">.+<script src="c_bundle.js">/], null, done);
   });
 
+  it('allows you to insert compiled assets content into html template', function(done) {
+    testHtmlPlugin({
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js'),
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        template: path.join(__dirname, 'fixtures/inline_compiled_assets.html'),
+      })]
+    }, ['webpackJsonp', 'module.exports = "common"'], null, done);
+  });
 });

--- a/spec/fixtures/inline_compiled_assets.html
+++ b/spec/fixtures/inline_compiled_assets.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+    <title>inline compiled assets</title>
+  </head>
+  <body>
+    <script>
+      <%= htmlWebpackPlugin.files.chunks.app.source() %>
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Support insert compiled assets content into html template like: 
`<script><%= htmlWebpackPlugin.files.chunks.main.source() %></script>`