### PR TITLE
Remove lodash as dependency, fix #172

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -22,5 +22,5 @@ module.exports = function (source) {
   // Use underscore for a minimalistic loader
   var options = loaderUtils.parseQuery(this.query);
   var template = _.template(source, options);
-  return 'var _ = require("lodash"); module.exports = ' + template;
+  return 'var _ = require("' + require.resolve('lodash') + '");module.exports = ' + template;
 };


### PR DESCRIPTION
This PR removes changes included with `commit b3913d04001f031342794c71acfc4a1bae4e01b3`.

Why?

- `commit b3913d` makes `lodash` a dependency for user's app. Not every user will use `lodash`. Those who don't use lodash will run into error.
- When I upgrade `html-webpack-plugin@2.1` to `html-webpack-plugin@2.6`, my build script crashed because of reason above. The `commit b3913d` leads to incompatibility.
- I think `escape` is not that important and we have other approach.


More details:

- <https://github.com/ampedandwired/html-webpack-plugin/pull/160> 
- <https://github.com/ampedandwired/html-webpack-plugin/issues/172>