### PR TITLE
Child compilation must use a separate cache object

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -50,6 +50,13 @@ module.exports.compileTemplate = function compileTemplate(template, context, out
     new SingleEntryPlugin(this.context, template),
     new LoaderTargetPlugin('node')
   );
+  childCompiler.plugin("compilation", function(compilation) {
+    if(compilation.cache) {
+      if(!compilation.cache[compilerName])
+        compilation.cache[compilerName] = {};
+      compilation.cache = compilation.cache[compilerName];
+    }
+  });
 
   // Compile and return a promise
   return new Promise(function (resolve, reject) {


### PR DESCRIPTION
fix for https://github.com/webpack/webpack/issues/1890

yes, I know, this should be done automatically by webpack when creating a child compilation...
I'll add it in the next major version...