### PR TITLE
Fix Webpack2 compatibility. Closes #213.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -3,6 +3,7 @@
 
 var _ = require('lodash');
 var loaderUtils = require('loader-utils');
+var templateConstructor = require('./template');
 
 module.exports = function (source) {
   if (this.cacheable) {
@@ -22,6 +23,8 @@ module.exports = function (source) {
   }
   // Use underscore for a minimalistic loader
   var options = loaderUtils.parseQuery(this.query);
-  var template = _.template(source, options);
-  return 'var _ = require(' + loaderUtils.stringifyRequest(this, require.resolve('lodash')) + ');module.exports = ' + template;
+  // Workaround for Webpack 1 & 2 compatibility.
+  // See issue#213.
+  var template = _.template(source, _.defaults(options, { variable: 'data' }));
+  return 'var _ = require(' + loaderUtils.stringifyRequest(this, require.resolve('lodash')) + ');module.exports = ' + templateConstructor(template);
 };

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,0 +1,21 @@
+/* This module returns a function constructor. It is necessary to maintain
+   backward compatibility with Webpack 1 while supporting Webpack 2.
+   Webpack 2 does not allow with() statements, which lodash templates use to unwrap
+   the parameters passed to the compiled template inside the scope. We therefore
+   need to unwrap them ourselves here. This is essentially what lodash does internally
+   (see lodash/template).
+
+   See issue#213 for more information.
+*/
+'use strict';
+
+module.exports = function (template) {
+  /* eslint-disable no-new-func */
+  return Function('attr',
+    'var webpack = attr.webpack;' +
+    'var webpackConfig = attr.webpackConfig;' +
+    'var htmlWebpackPlugin = attr.htmlWebpackPlugin;' +
+    'return ' + template.source + '();'
+  );
+  /* eslint-enable no-new-func */
+};


### PR DESCRIPTION
Fixes the issues with lodash templates using `with()` not being compatible with Webpack 2, while maintaining backwards compatibility.

Do not be put off by the Function() constructor, that is how the lodash template works internally as well.

The only downside to this fix is that, should arguments passed to the template functions change, they need to be added both in `index.js` and `template.js`. I refactored out the template compiler to a separate file for this reason, to ease this.