### PR TITLE
Add chunk hash to `assets.chunks`

### DIFF
--- a/index.js
+++ b/index.js
@@ -378,6 +378,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
     var entry = chunkFiles[0];
     assets.chunks[chunkName].size = chunk.size;
     assets.chunks[chunkName].entry = entry;
+    assets.chunks[chunkName].hash = chunk.hash;
     assets.js.push(entry);
 
     // Gather all css files

--- a/spec/fixtures/webpackconfig.html
+++ b/spec/fixtures/webpackconfig.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <p>Public path is <%= webpackConfig.output.publicPath %></p>
-    <script src="<%= htmlWebpackPlugin.files.chunks.app.entry %>"></script>
+    <script src="<%= htmlWebpackPlugin.files.chunks.app.entry %>?<%= htmlWebpackPlugin.files.chunks.app.hash %>"></script>
   </body>
 </html>


### PR DESCRIPTION
Add chunk hash to `assets.chunks` so can use it in template.
For some version control requirements, chunk hash may be more useful than compilation hash.
For example, if there are two chunks in page, but only one of them is changed, use chunk hash is more cache-friendly.