### PR TITLE
Test on alle LTS releases of Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - "0.12"
   - "0.10"
-  - "iojs"
+  - "4"


### PR DESCRIPTION
Io.js was never made LTS, so no real reason to test on it. And 4.2.x (now 4.3.1) is the LTS release since the merge

https://github.com/nodejs/LTS