### PR TITLE
Properly throw an error in compiler even when childCompilation is missing

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -71,7 +71,7 @@ module.exports.compileTemplate = function compileTemplate (template, context, ou
         delete compilation.assets[outputOptions.filename];
       }
       // Resolve / reject the promise
-      if (childCompilation.errors && childCompilation.errors.length) {
+      if (childCompilation && childCompilation.errors && childCompilation.errors.length) {
         var errorDetails = childCompilation.errors.map(function (error) {
           return error.message + (error.error ? ':\n' + error.error : '');
         }).join('\n');


### PR DESCRIPTION
For some errors, no other parameters to the function are even given,
only the error object in `err`.