### PR TITLE
build public path with correct hash value

### DIFF
--- a/index.js
+++ b/index.js
@@ -338,7 +338,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
 
   // Use the configured public path or build a relative path
   var publicPath = typeof compilation.options.output.publicPath !== 'undefined'
-    ? compilation.options.output.publicPath
+    ? compilation.mainTemplate.getPublicPath({hash: webpackStatsJson.hash})
     : path.relative(path.dirname(self.options.filename), '.').split(path.sep).join('/');
 
   if (publicPath.length && publicPath.substr(-1, 1) !== '/') {

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -355,6 +355,18 @@ describe('HtmlWebpackPlugin', function () {
     }, [/<script src="index_bundle_[0-9a-f]+\.js"*/], null, done);
   });
 
+  it('handles hashes in the directory which has the bundle file', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: path.join(__dirname, '../dist'),
+        publicPath: '/dist/[hash]/',
+        filename: 'index_bundle_[hash].js'
+      },
+      plugins: [new HtmlWebpackPlugin()]
+    }, [/<script src="\/dist\/[0-9a-f]+\/index_bundle_[0-9a-f]+\.js"*/], null, done);
+  });
+
   it('allows to append hashes to the assets', function (done) {
     testHtmlPlugin({
       entry: path.join(__dirname, 'fixtures/index.js'),


### PR DESCRIPTION
Currently if my webpack config has: `publicPath: "/dist/[hash]/"` then my output html file will have:  `<script src="/dist/[hash]/commons_11e1b2480d26bdc6c179.js">`

WIth this fix [hash] gets replaced with the actual hash value.