### PR TITLE
Inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,3 +253,52 @@ compilation.plugin('html-webpack-plugin-before-html-processing', function(htmlPl
   callback();
 });
 ```
+
+Inline CSS
+----------
+
+CSS can be inlined into the head element of the HTML by using the inline loader.
+Note that the plugin itself does not need any options set up for inlining:
+
+```javascript
+module: {
+  loaders: [
+    { test: /\.css$/, loader: HtmlWebpackPlugin.inline() }
+  ]           
+},
+plugins: [
+  new HtmlWebpackPlugin()
+]  
+```
+The inline loader can be the end of a chain of CSS loaders, though note that any prior loader must output pure CSS, not javascript.  This means that [css-loader](https://www.npmjs.com/package/css-loader) and [style-loader](https://www.npmjs.com/package/style-loader) cannot be used, though the very useful [post-css](https://www.npmjs.com/package/postcss-loader) loader can be:
+
+```javascript
+module: {
+  loaders: [
+    { test: /\.css$/, loader: HtmlWebpackPlugin.inline('postcss-loader') }
+  ]           
+},
+postcss: [
+  require('autoprefixer')
+],
+plugins: [
+  new HtmlWebpackPlugin()
+]  
+```
+
+You may also wish to minify the in-lined CSS; this requires specific `minify` options:
+
+```javascript
+module: {
+  loaders: [
+    { test: /\.css$/, loader: HtmlWebpackPlugin.inline() }
+  ]           
+},
+plugins: [
+  new HtmlWebpackPlugin({
+   minify: {
+    minifyCSS: true
+   }
+  })
+]  
+```

--- a/index.js
+++ b/index.js
@@ -537,10 +537,11 @@ HtmlWebpackPlugin.prototype.getAssetFiles = function (assets) {
 HtmlWebpackPlugin.inline = function (loaders) {
   var myLoader = require.resolve('./lib/inlineCssLoader.js');
   if (loaders) {
-    return [ myLoader ].concat(loaders).join('!');
+    loaders = [ myLoader ].concat(loaders).join('!');
   } else {
-    return myLoader;
+    loaders = myLoader;
   }
+  return loaders;
 };
 
 module.exports = HtmlWebpackPlugin;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var path = require('path');
 var childCompiler = require('./lib/compiler.js');
 var prettyError = require('./lib/errors.js');
 var chunkSorter = require('./lib/chunksorter.js');
+var inlineCssStore = require('./lib/inlineCssStore.js');
 Promise.promisifyAll(fs);
 
 function HtmlWebpackPlugin (options) {
@@ -419,6 +420,14 @@ HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function (html, assets) {
   var styles = assets.css.map(function (stylePath) {
     return '<link href="' + stylePath + '" rel="stylesheet">';
   });
+  // inline css?
+  var inlineCss = inlineCssStore.get();
+  if (inlineCss.length > 0) {
+    inlineCss = inlineCss.map(function (css) {
+      return '<style>' + css + '</style>';
+    });
+    styles = inlineCss.concat(styles);
+  }
   // Injections
   var htmlRegExp = /(<html[^>]*>)/i;
   var head = [];
@@ -520,6 +529,18 @@ HtmlWebpackPlugin.prototype.getAssetFiles = function (assets) {
   }, []));
   files.sort();
   return files;
+};
+
+/**
+ * Inject loader for in-line styles
+ */
+HtmlWebpackPlugin.inline = function (loaders) {
+  var myLoader = require.resolve('./lib/inlineCssLoader.js');
+  if (loaders) {
+    return [ myLoader ].concat(loaders).join('!');
+  } else {
+    return myLoader;
+  }
 };
 
 module.exports = HtmlWebpackPlugin;

--- a/lib/inlineCssLoader.js
+++ b/lib/inlineCssLoader.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var cssStore = require('./inlineCssStore.js');
+
+module.exports = function (content) {
+  cssStore.add(content);
+  return '/* removed by html-webpack-plugin */';
+};

--- a/lib/inlineCssStore.js
+++ b/lib/inlineCssStore.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var allCss = [];
+
+exports.add = function (css) {
+  allCss.push(css);
+};
+
+exports.get = function () {
+  return allCss;
+};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "jade": "^1.11.0",
     "jade-loader": "^0.8.0",
     "jasmine": "^2.4.1",
+    "postcss-loader": "^0.8.2",
+    "postcss-spiffing": "0.0.6",
     "rimraf": "^2.5.2",
     "semistandard": "^7.0.5",
     "style-loader": "^0.13.0",

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -1064,7 +1064,7 @@ describe('HtmlWebpackPlugin', function () {
     }, ['templateParams.compilation exists: true'], null, done);
   });
 
-  it('in-lines styles if the "inline: styles" option is set', function (done) {
+  it('inlines a stylesheet if the inline loader is specified', function (done) {
     testHtmlPlugin({
       entry: path.join(__dirname, 'fixtures/theme.js'),
       output: {
@@ -1073,14 +1073,73 @@ describe('HtmlWebpackPlugin', function () {
       },
       module: {
         loaders: [
-          { test: /\.css$/, loader: HtmlWebpackPlugin.inline() } // 'postcss-loader') } // 'raw') } // 'css-loader') }
+          { test: /\.css$/, loader: HtmlWebpackPlugin.inline() }
+        ]
+      },
+      plugins: [
+        new HtmlWebpackPlugin()
+      ]
+    }, [/<style>[\s\S]*<\/style>/], null, done);
+  });
+
+  it('inlines multiple stylesheets if the inline loader is specified', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/british_theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: HtmlWebpackPlugin.inline() }
+        ]
+      },
+      plugins: [
+        new HtmlWebpackPlugin()
+      ]
+    }, [/(<style>[\s\S]*<\/style>){2}/], null, done);
+  });
+
+  it('inlining works with postcss loader', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/british_theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: HtmlWebpackPlugin.inline('postcss-loader') }
+        ]
+      },
+      postcss: [
+        require('postcss-spiffing')
+      ],
+      plugins: [
+        new HtmlWebpackPlugin()
+      ]
+    }, [/color: gray/], null, done);
+  });
+
+  it('inlined stylesheets are minified if minify options are set', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/british_theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: HtmlWebpackPlugin.inline() }
         ]
       },
       plugins: [
         new HtmlWebpackPlugin({
-          inline: 'styles'
+          minify: {
+            minifyCSS: true
+          }
         })
       ]
-    }, [/<style>[\s\S]*<\/style>/], null, done);
+    }, [/(<style>.*<\/style>){2}/], null, done);
   });
 });

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -1063,4 +1063,24 @@ describe('HtmlWebpackPlugin', function () {
       ]
     }, ['templateParams.compilation exists: true'], null, done);
   });
+
+  it('in-lines styles if the "inline: styles" option is set', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: HtmlWebpackPlugin.inline() } // 'postcss-loader') } // 'raw') } // 'css-loader') }
+        ]
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          inline: 'styles'
+        })
+      ]
+    }, [/<style>[\s\S]*<\/style>/], null, done);
+  });
 });

--- a/spec/fixtures/british.css
+++ b/spec/fixtures/british.css
@@ -1,0 +1,3 @@
+body {
+  colour: grey;
+}

--- a/spec/fixtures/british_theme.js
+++ b/spec/fixtures/british_theme.js
@@ -1,0 +1,5 @@
+'use strict';
+
+require('./main.css');
+require('./british.css');
+require('./index.js');


### PR DESCRIPTION
Hi - my first GitHub pull request so apologies for anything missing and thanks in advance for any advice.
I have added in-lining the CSS as <style> tags in the generated HTML as opposed to using ExtractTextPlugin to pull into a separate CSS file and <link>'ing it.  Not everyone's Best Practice, but good for minimising number of requests and getting quick page loads in specific cases (especially with async scripts).
The technique is the same as ExtractTextPlugin (thanks Sokra!) - using a loader.  See the updated README.md for more.