### PR TITLE
add support for [hash] in filename

### DIFF
--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -38,6 +38,14 @@ function testHtmlPlugin (webpackConfig, expectedResults, outputFile, done, expec
     } else {
       expect(compilationWarnings).toBe('');
     }
+    if (outputFile instanceof RegExp) {
+      var matches = Object.keys(stats.compilation.assets).filter(function (item) {
+        return outputFile.test(item);
+      });
+      expect(matches.length).toBe(1);
+      outputFile = matches[0];
+    }
+    expect(outputFile.indexOf('[hash]') === -1).toBe(true);
     var outputFileExists = fs.existsSync(path.join(OUTPUT_DIR, outputFile));
     expect(outputFileExists).toBe(true);
     if (!outputFileExists) {
@@ -571,6 +579,19 @@ describe('HtmlWebpackPlugin', function () {
       },
       plugins: [new HtmlWebpackPlugin({filename: 'test.html'})]
     }, ['<script src="index_bundle.js"'], 'test.html', done);
+  });
+
+  it('will replace [hash] in the filename with the child compilation hash', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        filename: 'test-[hash].html'
+      })]
+    }, ['<script src="index_bundle.js"'], /test-\S+\.html$/, done);
   });
 
   it('allows you to use an absolute output filename', function (done) {

--- a/spec/CachingSpec.js
+++ b/spec/CachingSpec.js
@@ -10,6 +10,7 @@ if (!global.Promise) {
   require('es6-promise').polyfill();
 }
 
+var _ = require('lodash');
 var path = require('path');
 var webpack = require('webpack');
 var rm_rf = require('rimraf');
@@ -39,6 +40,14 @@ function getCompiledModuleCount (statsJson) {
   }, 0);
 }
 
+var baseConfigurations = [
+  {},
+  {
+    filename: 'test-[hash].html'
+  }
+];
+
+baseConfigurations.forEach(function (baseConfiguration) {
 describe('HtmlWebpackPluginCaching', function () {
   beforeEach(function (done) {
     rm_rf(OUTPUT_DIR, done);
@@ -46,9 +55,9 @@ describe('HtmlWebpackPluginCaching', function () {
 
   it('should compile nothing if no file was changed', function (done) {
     var template = path.join(__dirname, 'fixtures/plain.html');
-    var htmlWebpackPlugin = new HtmlWebpackPlugin({
+    var htmlWebpackPlugin = new HtmlWebpackPlugin(_.assign(baseConfiguration, {
       template: template
-    });
+    }));
     var childCompilerHash;
     var compiler = setUpCompiler(htmlWebpackPlugin);
     compiler.run()
@@ -72,7 +81,7 @@ describe('HtmlWebpackPluginCaching', function () {
   });
 
   it('should not compile the webpack html file if only a javascript file was changed', function (done) {
-    var htmlWebpackPlugin = new HtmlWebpackPlugin();
+    var htmlWebpackPlugin = new HtmlWebpackPlugin(baseConfiguration);
     var compiler = setUpCompiler(htmlWebpackPlugin);
     var childCompilerHash;
     compiler.run()
@@ -97,9 +106,9 @@ describe('HtmlWebpackPluginCaching', function () {
   });
 
   it('should compile the webpack html file even if only a javascript file was changed if caching is disabled', function (done) {
-    var htmlWebpackPlugin = new HtmlWebpackPlugin({
+    var htmlWebpackPlugin = new HtmlWebpackPlugin(_.assign(baseConfiguration, {
       cache: false
-    });
+    }));
     var childCompilerHash;
     var compiler = setUpCompiler(htmlWebpackPlugin);
     compiler.run()
@@ -125,9 +134,9 @@ describe('HtmlWebpackPluginCaching', function () {
 
   it('should compile the webpack html if the template file was changed', function (done) {
     var template = path.join(__dirname, 'fixtures/plain.html');
-    var htmlWebpackPlugin = new HtmlWebpackPlugin({
+    var htmlWebpackPlugin = new HtmlWebpackPlugin(_.assign(baseConfiguration, {
       template: template
-    });
+    }));
     var childCompilerHash;
     var compiler = setUpCompiler(htmlWebpackPlugin);
     compiler.run()
@@ -150,4 +159,5 @@ describe('HtmlWebpackPluginCaching', function () {
       })
       .then(done);
   });
+});
 });

--- a/spec/CachingSpec.js
+++ b/spec/CachingSpec.js
@@ -48,116 +48,116 @@ var baseConfigurations = [
 ];
 
 baseConfigurations.forEach(function (baseConfiguration) {
-describe('HtmlWebpackPluginCaching', function () {
-  beforeEach(function (done) {
-    rm_rf(OUTPUT_DIR, done);
-  });
+  describe('HtmlWebpackPluginCaching', function () {
+    beforeEach(function (done) {
+      rm_rf(OUTPUT_DIR, done);
+    });
 
-  it('should compile nothing if no file was changed', function (done) {
-    var template = path.join(__dirname, 'fixtures/plain.html');
-    var htmlWebpackPlugin = new HtmlWebpackPlugin(_.assign(baseConfiguration, {
-      template: template
-    }));
-    var childCompilerHash;
-    var compiler = setUpCompiler(htmlWebpackPlugin);
-    compiler.run()
-      // Change the template file and compile again
-      .then(function () {
-        childCompilerHash = htmlWebpackPlugin.childCompilerHash;
-        return compiler.run();
-      })
-      .then(function (stats) {
-        // Verify that no file was built
-        expect(getCompiledModuleCount(stats.toJson()))
-          .toBe(0);
-        // Verify that the html was processed only during the inital build
-        expect(htmlWebpackPlugin.evaluateCompilationResult.calls.count())
-          .toBe(1);
-        // Verify that the child compilation was executed twice
-        expect(htmlWebpackPlugin.childCompilerHash)
-          .toBe(childCompilerHash);
-      })
-      .then(done);
-  });
+    it('should compile nothing if no file was changed', function (done) {
+      var template = path.join(__dirname, 'fixtures/plain.html');
+      var htmlWebpackPlugin = new HtmlWebpackPlugin(_.assign(baseConfiguration, {
+        template: template
+      }));
+      var childCompilerHash;
+      var compiler = setUpCompiler(htmlWebpackPlugin);
+      compiler.run()
+        // Change the template file and compile again
+        .then(function () {
+          childCompilerHash = htmlWebpackPlugin.childCompilerHash;
+          return compiler.run();
+        })
+        .then(function (stats) {
+          // Verify that no file was built
+          expect(getCompiledModuleCount(stats.toJson()))
+            .toBe(0);
+          // Verify that the html was processed only during the inital build
+          expect(htmlWebpackPlugin.evaluateCompilationResult.calls.count())
+            .toBe(1);
+          // Verify that the child compilation was executed twice
+          expect(htmlWebpackPlugin.childCompilerHash)
+            .toBe(childCompilerHash);
+        })
+        .then(done);
+    });
 
-  it('should not compile the webpack html file if only a javascript file was changed', function (done) {
-    var htmlWebpackPlugin = new HtmlWebpackPlugin(baseConfiguration);
-    var compiler = setUpCompiler(htmlWebpackPlugin);
-    var childCompilerHash;
-    compiler.run()
-      // Change a js file and compile again
-      .then(function () {
-        childCompilerHash = htmlWebpackPlugin.childCompilerHash;
-        compiler.simulateFileChange(path.join(__dirname, 'fixtures/index.js'), {footer: '//1'});
-        return compiler.run();
-      })
-      .then(function (stats) {
-        // Verify that only one file was built
-        expect(getCompiledModuleCount(stats.toJson()))
-          .toBe(1);
-        // Verify that the html was processed only during the inital build
-        expect(htmlWebpackPlugin.evaluateCompilationResult.calls.count())
-          .toBe(1);
-        // Verify that the child compilation was executed only once
-        expect(htmlWebpackPlugin.childCompilerHash)
-          .toBe(childCompilerHash);
-      })
-      .then(done);
-  });
+    it('should not compile the webpack html file if only a javascript file was changed', function (done) {
+      var htmlWebpackPlugin = new HtmlWebpackPlugin(baseConfiguration);
+      var compiler = setUpCompiler(htmlWebpackPlugin);
+      var childCompilerHash;
+      compiler.run()
+        // Change a js file and compile again
+        .then(function () {
+          childCompilerHash = htmlWebpackPlugin.childCompilerHash;
+          compiler.simulateFileChange(path.join(__dirname, 'fixtures/index.js'), {footer: '//1'});
+          return compiler.run();
+        })
+        .then(function (stats) {
+          // Verify that only one file was built
+          expect(getCompiledModuleCount(stats.toJson()))
+            .toBe(1);
+          // Verify that the html was processed only during the inital build
+          expect(htmlWebpackPlugin.evaluateCompilationResult.calls.count())
+            .toBe(1);
+          // Verify that the child compilation was executed only once
+          expect(htmlWebpackPlugin.childCompilerHash)
+            .toBe(childCompilerHash);
+        })
+        .then(done);
+    });
 
-  it('should compile the webpack html file even if only a javascript file was changed if caching is disabled', function (done) {
-    var htmlWebpackPlugin = new HtmlWebpackPlugin(_.assign(baseConfiguration, {
-      cache: false
-    }));
-    var childCompilerHash;
-    var compiler = setUpCompiler(htmlWebpackPlugin);
-    compiler.run()
-      // Change a js file and compile again
-      .then(function () {
-        childCompilerHash = htmlWebpackPlugin.childCompilerHash;
-        compiler.simulateFileChange(path.join(__dirname, 'fixtures/index.js'), {footer: '//1'});
-        return compiler.run();
-      })
-      .then(function (stats) {
-        // Verify that only one file was built
-        expect(getCompiledModuleCount(stats.toJson()))
-          .toBe(1);
-        // Verify that the html was processed on every run
-        expect(htmlWebpackPlugin.evaluateCompilationResult.calls.count())
-          .toBe(2);
-        // Verify that the child compilation was executed only once
-        expect(htmlWebpackPlugin.childCompilerHash)
-          .toBe(childCompilerHash);
-      })
-      .then(done);
-  });
+    it('should compile the webpack html file even if only a javascript file was changed if caching is disabled', function (done) {
+      var htmlWebpackPlugin = new HtmlWebpackPlugin(_.assign(baseConfiguration, {
+        cache: false
+      }));
+      var childCompilerHash;
+      var compiler = setUpCompiler(htmlWebpackPlugin);
+      compiler.run()
+        // Change a js file and compile again
+        .then(function () {
+          childCompilerHash = htmlWebpackPlugin.childCompilerHash;
+          compiler.simulateFileChange(path.join(__dirname, 'fixtures/index.js'), {footer: '//1'});
+          return compiler.run();
+        })
+        .then(function (stats) {
+          // Verify that only one file was built
+          expect(getCompiledModuleCount(stats.toJson()))
+            .toBe(1);
+          // Verify that the html was processed on every run
+          expect(htmlWebpackPlugin.evaluateCompilationResult.calls.count())
+            .toBe(2);
+          // Verify that the child compilation was executed only once
+          expect(htmlWebpackPlugin.childCompilerHash)
+            .toBe(childCompilerHash);
+        })
+        .then(done);
+    });
 
-  it('should compile the webpack html if the template file was changed', function (done) {
-    var template = path.join(__dirname, 'fixtures/plain.html');
-    var htmlWebpackPlugin = new HtmlWebpackPlugin(_.assign(baseConfiguration, {
-      template: template
-    }));
-    var childCompilerHash;
-    var compiler = setUpCompiler(htmlWebpackPlugin);
-    compiler.run()
-      // Change the template file and compile again
-      .then(function () {
-        childCompilerHash = htmlWebpackPlugin.childCompilerHash;
-        compiler.simulateFileChange(template, {footer: '<!-- 1 -->'});
-        return compiler.run();
-      })
-      .then(function (stats) {
-        // Verify that only one file was built
-        expect(getCompiledModuleCount(stats.toJson()))
-          .toBe(1);
-        // Verify that the html was processed twice
-        expect(htmlWebpackPlugin.evaluateCompilationResult.calls.count())
-          .toBe(2);
-        // Verify that the child compilation was executed twice
-        expect(htmlWebpackPlugin.childCompilerHash)
-          .not.toBe(childCompilerHash);
-      })
-      .then(done);
+    it('should compile the webpack html if the template file was changed', function (done) {
+      var template = path.join(__dirname, 'fixtures/plain.html');
+      var htmlWebpackPlugin = new HtmlWebpackPlugin(_.assign(baseConfiguration, {
+        template: template
+      }));
+      var childCompilerHash;
+      var compiler = setUpCompiler(htmlWebpackPlugin);
+      compiler.run()
+        // Change the template file and compile again
+        .then(function () {
+          childCompilerHash = htmlWebpackPlugin.childCompilerHash;
+          compiler.simulateFileChange(template, {footer: '<!-- 1 -->'});
+          return compiler.run();
+        })
+        .then(function (stats) {
+          // Verify that only one file was built
+          expect(getCompiledModuleCount(stats.toJson()))
+            .toBe(1);
+          // Verify that the html was processed twice
+          expect(htmlWebpackPlugin.evaluateCompilationResult.calls.count())
+            .toBe(2);
+          // Verify that the child compilation was executed twice
+          expect(htmlWebpackPlugin.childCompilerHash)
+            .not.toBe(childCompilerHash);
+        })
+        .then(done);
+    });
   });
-});
 });


### PR DESCRIPTION
This PR adds support for replacing `[hash]` in the filename with the hash of the compiled template. 

This behavior was brought up in #121 and would be pretty helpful for me.


