### PR TITLE
Async attribute for <script> tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ bundles in the body using `script` tags. Just add the plugin to your webpack
 config as follows:
 
 ```javascript
-var HtmlWebpackPlugin = require('html-webpack-plugin');
+var HtmlWebpackPlugin = require('html-webpack-plugin')
 var webpackConfig = {
   entry: 'index.js',
   output: {
@@ -39,7 +39,7 @@ var webpackConfig = {
     filename: 'index_bundle.js'
   },
   plugins: [new HtmlWebpackPlugin()]
-};
+}
 ```
 
 This will generate a file `dist/index.html` containing the following:
@@ -73,6 +73,8 @@ Allowed values are as follows:
    You can specify a subdirectory here too (eg: `assets/admin.html`).
 - `template`: Path to the template. Supports loaders e.g. `html!./index.html`.
 - `inject`: `true | 'head' | 'body' | false` Inject all assets into the given `template` or `templateContent` - When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element.
+- `async`: `true | false` if `true` the `async` attribute is added to `script` tags; default is
+`false'.
 - `favicon`: Adds the given favicon path to the output html.
 - `minify`: `{...} | false` Pass a [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference) options object to minify the output.
 - `hash`: `true | false` if `true` then append a unique webpack compilation hash to all

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Allowed values are as follows:
    You can specify a subdirectory here too (eg: `assets/admin.html`).
 - `template`: Path to the template. Supports loaders e.g. `html!./index.html`.
 - `inject`: `true | 'head' | 'body' | false` Inject all assets into the given `template` or `templateContent` - When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element.
-- `async`: `true | false` if `true` the `async` attribute is added to `script` tags; default is
-`false'.
+- `asyncDefault`: `true | false` Default is `false' - see [Async](#async) section below.
+- `asyncExceptions`: array of `String`'s and/or `RegExp`'s defining scripts that do the opposite of
+the `asyncDefault` flag - see [Async](#async) section below.
 - `favicon`: Adds the given favicon path to the output html.
 - `minify`: `{...} | false` Pass a [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference) options object to minify the output.
 - `hash`: `true | false` if `true` then append a unique webpack compilation hash to all
@@ -254,4 +255,35 @@ compilation.plugin('html-webpack-plugin-before-html-processing', function(htmlPl
   htmlPluginData.html += 'The magic footer';
   callback();
 });
+```
+<a name="async"></a>
+Async
+-----
+
+`<script>` tags are by default added without the `async` attribute.  This can be changed by setting
+the `asyncDefault` option to `true`.
+
+However you may wish to combine sync and async scripts.  This can be done by adding the
+`asyncExceptions` option and defining an array of `String`s and/or `RegExp`s (you can have both) that match script names
+which should have the *opposite* of the `asyncDefault` option.  
+
+A contrived example where all but 'app_bundle.js' are marked as `async`:
+
+```javascript
+entry: {
+  util: 'util.js',
+  module1: 'module1.js',
+  module2: 'module2.js'
+  app: 'app.js'
+},
+output: {
+  filename: '[name]_bundle.js'
+},
+plugins: [ 
+  new HtmlWebpackPlugin({
+    asyncDefault: false,
+    asyncExceptions: [/module.*/,'util_bundle.js']
+  }) 
+]  
+
 ```

--- a/index.js
+++ b/index.js
@@ -411,9 +411,10 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
  * Injects the assets into the given html string
  */
 HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function (html, assets) {
-  // Turn script files into script tags
+   // Turn script files into script tags
+  var asyncAttribute = this.options.async ? ' async' : '';
   var scripts = assets.js.map(function (scriptPath) {
-    return '<script src="' + scriptPath + '"></script>';
+    return '<script src="' + scriptPath + '"' + asyncAttribute + '></script>';
   });
   // Turn css files into link tags
   var styles = assets.css.map(function (stylePath) {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ function HtmlWebpackPlugin (options) {
     showErrors: true,
     chunks: 'all',
     excludeChunks: [],
-    title: 'Webpack App'
+    title: 'Webpack App',
+    asyncDefault: false,
+    asyncExceptions: []
   }, options);
 }
 
@@ -407,14 +409,28 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
   return assets;
 };
 
+HtmlWebpackPlugin.prototype.asyncAttribute = function (scriptPath) {
+  var ASYNC = ' async';
+  var SYNC = '';
+  for (var i = 0; i < this.options.asyncExceptions.length; i++) {
+    var exception = this.options.asyncExceptions[i];
+    if (exception === scriptPath) {
+      return this.options.asyncDefault ? SYNC : ASYNC;
+    } else if (exception instanceof RegExp && exception.test(scriptPath)) {
+      return this.options.asyncDefault ? SYNC : ASYNC;
+    }
+  }
+  return this.options.asyncDefault ? ASYNC : SYNC;
+};
+
 /**
  * Injects the assets into the given html string
  */
 HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function (html, assets) {
-   // Turn script files into script tags
-  var asyncAttribute = this.options.async ? ' async' : '';
+  var self = this;
+  // Turn script files into script tags
   var scripts = assets.js.map(function (scriptPath) {
-    return '<script src="' + scriptPath + '"' + asyncAttribute + '></script>';
+    return '<script src="' + scriptPath + '"' + self.asyncAttribute(scriptPath) + '></script>';
   });
   // Turn css files into link tags
   var styles = assets.css.map(function (stylePath) {

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -1064,7 +1064,7 @@ describe('HtmlWebpackPlugin', function () {
     }, ['templateParams.compilation exists: true'], null, done);
   });
 
-  it('marks script files as async if async flag set', function (done) {
+  it('marks script file as async if async default set to true', function (done) {
     testHtmlPlugin({
       entry: path.join(__dirname, 'fixtures/index.js'),
       output: {
@@ -1072,8 +1072,67 @@ describe('HtmlWebpackPlugin', function () {
         filename: 'index_bundle.js'
       },
       plugins: [new HtmlWebpackPlugin({
-        async: true
+        asyncDefault: true
       })]
     }, [/<body>[\s]*<script src="index_bundle.js" async><\/script>[\s]*<\/body>/], null, done);
+  });
+  it('marks script file as async if async default set to false but script file marked as exception', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        // asyncDefault default value is false
+        asyncExceptions: ['index_bundle.js']
+      })]
+    }, [/<body>[\s]*<script src="index_bundle.js" async><\/script>[\s]*<\/body>/], null, done);
+  });
+
+  it('does not mark script file as async if async default set to true but script file marked as exception', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        asyncDefault: true,
+        asyncExceptions: ['index_bundle.js']
+      })]
+    }, [/<body>[\s]*<script src="index_bundle.js"><\/script>[\s]*<\/body>/], null, done);
+  });
+
+  it('async exceptions work with regular expressions', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        // asyncDefault default value is false
+        asyncExceptions: [/in.*.js/]
+      })]
+    }, [/<body>[\s]*<script src="index_bundle.js" async><\/script>[\s]*<\/body>/], null, done);
+  });
+
+  it('selective async exceptions working (and supporting hashing)', function (done) {
+    testHtmlPlugin({
+      entry: {
+        util: path.join(__dirname, 'fixtures/util.js'),
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        hash: true,
+        asyncDefault: true,
+        asyncExceptions: ['wibble.js', /app.*/]
+      })]
+    }, ['<script src="util_bundle.js?%hash%" async', '<script src="app_bundle.js?%hash%"'], null, done);
   });
 });

--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -1063,4 +1063,17 @@ describe('HtmlWebpackPlugin', function () {
       ]
     }, ['templateParams.compilation exists: true'], null, done);
   });
+
+  it('marks script files as async if async flag set', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        async: true
+      })]
+    }, [/<body>[\s]*<script src="index_bundle.js" async><\/script>[\s]*<\/body>/], null, done);
+  });
 });


### PR DESCRIPTION
You probably have solutions for this as the functional change is trivial.
However this is my go at a convenient options syntax to permit flexibility in defining *which* scripts are marked as 'async'.