### PR TITLE
Keep favicon.ico at Root of Project

### DIFF
--- a/index.js
+++ b/index.js
@@ -443,7 +443,7 @@ HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function (html, assets) {
 
   // If there is a favicon present, add it to the head
   if (assets.favicon) {
-    head.push('<link rel="shortcut icon" href="' + assets.favicon + '"' + xhtml + '>');
+    head.push('<link rel="shortcut icon" href="/' + assets.favicon + '"' + xhtml + '>');
   }
   // Add styles to the head
   head = head.concat(styles);


### PR DESCRIPTION
I have an issue where the favicon.ico is missing in subdirectories. Since this plugin only copies the favicon.ico to the root of the project, the path should be absolute.