### PR TITLE
Don’t emit the html for hot-update compilation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,12 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
     chunks = self.sortChunks(chunks, self.options.chunksSortMode);
     // Get assets
     var assets = self.htmlWebpackPluginAssets(compilation, chunks);
+    // If this is a hot update compilation, move on!
+    // This solves a problem where an `index.html` file is generated for hot-update js files
+    // It only happens in Webpack 2, where hot updates are emitted separately before the full bundle
+    if (self.isHotUpdateCompilation(assets)) {
+      return callback();
+    }
 
     // If the template and the assets did not change we don't have to emit the html
     var assetJson = JSON.stringify(self.getAssetFiles(assets));
@@ -337,6 +343,12 @@ HtmlWebpackPlugin.prototype.filterChunks = function (webpackStatsJson, includedC
     }
     // Add otherwise
     return true;
+  });
+};
+
+HtmlWebpackPlugin.prototype.isHotUpdateCompilation = function (assets) {
+  return assets.js.every(function (name) {
+    return /\.hot-update\.js$/.test(name);
   });
 };
 


### PR DESCRIPTION
webpack-dev-server@2.0.0-beta seems to be emitting hot update bundles separately from the full bundle. This makes HtmlWebpackPlugin mistake it for the real bundle, and generates a HTML file that looks like this:

```html
<script src="0.8f9c33574d86dd9eab0d.hot-update.js"></scriptt>
```

This commit uses quite a hack to check if the emitted bundle is a hot-update bundle, and skip emitting `index.html` file.