### PR TITLE
Issue with publicPath and custom template

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ HtmlWebpackPlugin.prototype.evaluateCompilationResult = function (compilation, s
   // The LibraryTemplatePlugin stores the template result in a local variable.
   // To extract the result during the evaluation this part has to be removed.
   source = source.replace('var HTML_WEBPACK_PLUGIN_RESULT =', '')
-    .replace(/(__webpack_require__\.p\s=\s\")[\s\S]*/, ['$1', compilation.mainTemplate.getPublicPath({hash: compilation.hash }), '"'].join(''));
+    .replace(/(__webpack_require__\.p\s=\s\")[\s\S]*?\"/, ['$1', compilation.mainTemplate.getPublicPath({hash: compilation.hash }), '"'].join(''));
   var template = this.options.template.replace(/^.+!/, '').replace(/\?.+$/, '');
   var vmContext = vm.createContext(_.extend({HTML_WEBPACK_PLUGIN: true, require: require}, global));
   var vmScript = new vm.Script(source, {filename: template});

--- a/index.js
+++ b/index.js
@@ -188,7 +188,8 @@ HtmlWebpackPlugin.prototype.evaluateCompilationResult = function (compilation, s
 
   // The LibraryTemplatePlugin stores the template result in a local variable.
   // To extract the result during the evaluation this part has to be removed.
-  source = source.replace('var HTML_WEBPACK_PLUGIN_RESULT =', '');
+  source = source.replace('var HTML_WEBPACK_PLUGIN_RESULT =', '')
+    .replace(/(__webpack_require__\.p\s=\s\")[\s\S]*/, ['$1', compilation.mainTemplate.getPublicPath({hash: compilation.hash }), '"'].join(''));
   var template = this.options.template.replace(/^.+!/, '').replace(/\?.+$/, '');
   var vmContext = vm.createContext(_.extend({HTML_WEBPACK_PLUGIN: true, require: require}, global));
   var vmScript = new vm.Script(source, {filename: template});

--- a/index.js
+++ b/index.js
@@ -186,10 +186,19 @@ HtmlWebpackPlugin.prototype.evaluateCompilationResult = function (compilation, s
     return Promise.reject('The child compilation didn\'t provide a result');
   }
 
+  // If custom template proceed though loader which have link to external assets with [hash].
+  // We need to replace publicPath to publicPath of main compilation
+  var publicPathTemplate = _.get(compilation, 'options.output.publicPath');
+  var regexp = /(__webpack_require__\.p\s=\s\")[\s\S]*?(\")/;
+  var target = ['$1', this.compilationPublicPath, '$2'].join('');
+
+  if (publicPathTemplate && publicPathTemplate.indexOf('[hash]') !== -1) {
+    source = source.replace(regexp, target);
+  }
+
   // The LibraryTemplatePlugin stores the template result in a local variable.
   // To extract the result during the evaluation this part has to be removed.
-  source = source.replace('var HTML_WEBPACK_PLUGIN_RESULT =', '')
-    .replace(/(__webpack_require__\.p\s=\s\")[\s\S]*?\"/, ['$1', compilation.mainTemplate.getPublicPath({hash: compilation.hash }), '"'].join(''));
+  source = source.replace('var HTML_WEBPACK_PLUGIN_RESULT =', '');
   var template = this.options.template.replace(/^.+!/, '').replace(/\?.+$/, '');
   var vmContext = vm.createContext(_.extend({HTML_WEBPACK_PLUGIN: true, require: require}, global));
   var vmScript = new vm.Script(source, {filename: template});
@@ -346,7 +355,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
   var webpackStatsJson = compilation.getStats().toJson();
 
   // Use the configured public path or build a relative path
-  var publicPath = typeof compilation.options.output.publicPath !== 'undefined'
+  var publicPath = self.compilationPublicPath = typeof compilation.options.output.publicPath !== 'undefined'
     // If a hard coded public path exists use it
     ? compilation.mainTemplate.getPublicPath({hash: webpackStatsJson.hash})
     // If no public path was set get a relative url path


### PR DESCRIPTION
 Hello. Please review this bug fix.

## Reason:

I have custom html template which proceed though my loader like html-loader (this bug was replicated with html-loader also)
my template have this line
```
<link rel="icon" href="/images/favicon.ico" type="image/x-icon" />
```
(way with favicon option does not suit me)

href attr converted to [my_dist_directory_with_hash]/images/favicon.ico
my publicPath option for webpack is '/dist/somepath/[hash]/'

after html was emit, attr converted to 

[html_plugin_child_compiler_webpack_publicPath]/images/favicon.ico
![html-webpack-plugin](https://cloud.githubusercontent.com/assets/2514038/14251336/227618aa-fa8b-11e5-8cf1-b6c60493797e.jpg)


not my publicPath;
I was found only this way for fix this issue)

P.S. Sorry for my English...)))