### PR TITLE
Update peerDependencies to support use with Webpack 2 beta and npm2

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "toposort": "^1.0.0"
   },
   "peerDependencies": {
-    "webpack": "*"
+    "webpack": "1 || ^2.1.0-beta"
   }
 }


### PR DESCRIPTION
This makes `peerDependences` match what other Webpack 2 beta compatible loaders and plugins I'm using are doing, as `*` doesn't seem to match pre-release versions.

Making this change locally fixed a `peerDependency` error I was getting installing Webpack 2 beta and dependencies with npm2, which makes `npm install` with that version of npm.