### PR TITLE
replace [hash] in publicPath of favicon

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
         if (self.options.favicon) {
           return self.addFileToAssets(self.options.favicon, compilation)
             .then(function (faviconBasename) {
-              var publicPath = compilation.options.output.publicPath || '';
+              var publicPath = compilation.mainTemplate.getPublicPath({hash: compilation.hash}) || '';
               if (publicPath && publicPath.substr(-1) !== '/') {
                 publicPath += '/';
               }

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -1007,6 +1007,22 @@ describe('HtmlWebpackPlugin', function () {
     }, [/<link rel="shortcut icon" href="\/some\/+[^"]+\.ico">/], null, done);
   });
 
+  it('adds a favicon with a publichPath set to [hash]/ and replaces the hash', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        publicPath: '/[hash]/',
+        filename: 'index_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          favicon: path.join(__dirname, 'fixtures/favicon.ico')
+        })
+      ]
+    }, [/<link rel="shortcut icon" href="\/*\/+[^"]+\.ico">/], null, done);
+  });
+
   it('adds a favicon with inject enabled', function (done) {
     testHtmlPlugin({
       entry: path.join(__dirname, 'fixtures/index.js'),

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -1020,7 +1020,7 @@ describe('HtmlWebpackPlugin', function () {
           favicon: path.join(__dirname, 'fixtures/favicon.ico')
         })
       ]
-    }, [/<link rel="shortcut icon" href="\/*\/+[^"]+\.ico">/], null, done);
+    }, [/<link rel="shortcut icon" href="\/[a-z0-9]{20}\/favicon\.ico">/], null, done);
   });
 
   it('adds a favicon with inject enabled', function (done) {


### PR DESCRIPTION
[hash] replacement works for pretty much all asset types but if the publicPath includes the build hash it does not get replaced and the final html output for the favicon and still contains the [hash] placeholder. this change replaces the [hash] variable in the publicPath for the favicon.