### PR TITLE
Made before and after "html-processing" events use callback value

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
         var pluginArgs = {html: html, assets: assets, plugin: self, outputName: self.childCompilationOutputName};
         return applyPluginsAsyncWaterfall('html-webpack-plugin-before-html-processing', pluginArgs)
           .then(function (newPluginArgs) {
-            return newPluginArgs && newPluginArgs.html || pluginArgs.html;
+            return newPluginArgs ? newPluginArgs.html : pluginArgs.html;
           });
       })
       .then(function (html) {
@@ -158,7 +158,7 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
         var pluginArgs = {html: html, assets: assets, plugin: self, outputName: self.childCompilationOutputName};
         return applyPluginsAsyncWaterfall('html-webpack-plugin-after-html-processing', pluginArgs)
           .then(function (newPluginArgs) {
-            return newPluginArgs && newPluginArgs.html || pluginArgs.html;
+            return newPluginArgs ? newPluginArgs.html : pluginArgs.html;
           });
       })
       .catch(function (err) {

--- a/index.js
+++ b/index.js
@@ -138,8 +138,8 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
       .then(function (html) {
         var pluginArgs = {html: html, assets: assets, plugin: self, outputName: self.childCompilationOutputName};
         return applyPluginsAsyncWaterfall('html-webpack-plugin-before-html-processing', pluginArgs)
-          .then(function () {
-            return pluginArgs.html;
+          .then(function (newPluginArgs) {
+            return newPluginArgs && newPluginArgs.html || pluginArgs.html;
           });
       })
       .then(function (html) {
@@ -157,8 +157,8 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
       .then(function (html) {
         var pluginArgs = {html: html, assets: assets, plugin: self, outputName: self.childCompilationOutputName};
         return applyPluginsAsyncWaterfall('html-webpack-plugin-after-html-processing', pluginArgs)
-          .then(function () {
-            return pluginArgs.html;
+          .then(function (newPluginArgs) {
+            return newPluginArgs && newPluginArgs.html || pluginArgs.html;
           });
       })
       .catch(function (err) {

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
         var chunks = result.chunks;
         // Prepare script and link tags
         var assetTags = self.generateAssetTags(assets);
-        var pluginArgs = {head: assetTags.head, body: assetTags.body, plugin: self, chunks: chunks, outputName: self.childCompilationOutputName, assets: assets, html: html};
+        var pluginArgs = {head: assetTags.head, body: assetTags.body, plugin: self, chunks: chunks, outputName: self.childCompilationOutputName};
         // Allow plugins to change the assetTag definitions
         return applyPluginsAsyncWaterfall('html-webpack-plugin-alter-asset-tags', pluginArgs)
           .then(function (result) {
@@ -156,7 +156,7 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
               // Add the stylesheets, scripts and so on to the resulting html
             return self.postProcessHtml(html, assets, { body: body, head: head })
               .then(function (html) {
-                return _.extend(result, {html: html});
+                return _.extend(result, {html: html, assets: assets});
               });
           });
       })

--- a/index.js
+++ b/index.js
@@ -626,6 +626,9 @@ HtmlWebpackPlugin.prototype.applyPluginsAsyncWaterfall = function (compilation) 
   return function (eventName, pluginArgs) {
     return promisedApplyPluginsAsyncWaterfall(eventName, pluginArgs)
       .then(function (result) {
+        if (!result) {
+          compilation.warnings.push(new Error('Using html-webpack-plugin-after-html-processing without returning a result is deprecated.'));
+        }
         return _.extend(pluginArgs, result);
       });
   };

--- a/index.js
+++ b/index.js
@@ -149,12 +149,8 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
         // Allow plugins to change the assetTag definitions
         return applyPluginsAsyncWaterfall('html-webpack-plugin-alter-asset-tags', pluginArgs)
           .then(function (result) {
-            var html = result.html;
-            var assets = result.assets;
-            var body = result.body;
-            var head = result.head;
               // Add the stylesheets, scripts and so on to the resulting html
-            return self.postProcessHtml(html, assets, { body: body, head: head })
+            return self.postProcessHtml(html, assets, { body: result.body, head: result.head })
               .then(function (html) {
                 return _.extend(result, {html: html, assets: assets});
               });

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
   });
 
   compiler.plugin('emit', function (compilation, callback) {
-    var applyPluginsAsyncWaterfall = Promise.promisify(compilation.applyPluginsAsyncWaterfall, {context: compilation});
+    var applyPluginsAsyncWaterfall = self.applyPluginsAsyncWaterfall(compilation);
     // Get all chunks
     var chunks = self.filterChunks(compilation.getStats().toJson(), self.options.chunks, self.options.excludeChunks);
     // Sort chunks
@@ -137,28 +137,37 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
       // Allow plugins to change the html before assets are injected
       .then(function (html) {
         var pluginArgs = {html: html, assets: assets, plugin: self, outputName: self.childCompilationOutputName};
-        return applyPluginsAsyncWaterfall('html-webpack-plugin-before-html-processing', pluginArgs)
-          .then(function (newPluginArgs) {
-            return newPluginArgs ? newPluginArgs.html : pluginArgs.html;
-          });
+        return applyPluginsAsyncWaterfall('html-webpack-plugin-before-html-processing', pluginArgs);
       })
-      .then(function (html) {
+      .then(function (result) {
+        var html = result.html;
+        var assets = result.assets;
+        var chunks = result.chunks;
         // Prepare script and link tags
         var assetTags = self.generateAssetTags(assets);
-        var pluginArgs = {head: assetTags.head, body: assetTags.body, plugin: self, chunks: chunks, outputName: self.childCompilationOutputName};
+        var pluginArgs = {head: assetTags.head, body: assetTags.body, plugin: self, chunks: chunks, outputName: self.childCompilationOutputName, assets: assets, html: html};
         // Allow plugins to change the assetTag definitions
         return applyPluginsAsyncWaterfall('html-webpack-plugin-alter-asset-tags', pluginArgs)
-          .then(function () {
+          .then(function (result) {
+            var html = result.html;
+            var assets = result.assets;
+            var body = result.body;
+            var head = result.head;
               // Add the stylesheets, scripts and so on to the resulting html
-            return self.postProcessHtml(html, assets, { body: pluginArgs.body, head: pluginArgs.head });
+            return self.postProcessHtml(html, assets, { body: body, head: head })
+              .then(function (html) {
+                return _.extend(result, {html: html});
+              });
           });
       })
       // Allow plugins to change the html after assets are injected
-      .then(function (html) {
+      .then(function (result) {
+        var html = result.html;
+        var assets = result.assets;
         var pluginArgs = {html: html, assets: assets, plugin: self, outputName: self.childCompilationOutputName};
         return applyPluginsAsyncWaterfall('html-webpack-plugin-after-html-processing', pluginArgs)
-          .then(function (newPluginArgs) {
-            return newPluginArgs ? newPluginArgs.html : pluginArgs.html;
+          .then(function (result) {
+            return result.html;
           });
       })
       .catch(function (err) {
@@ -610,6 +619,20 @@ HtmlWebpackPlugin.prototype.getAssetFiles = function (assets) {
   }, []));
   files.sort();
   return files;
+};
+
+/**
+ * Helper to promisify compilation.applyPluginsAsyncWaterfall that returns
+ * a function that helps to merge given plugin arguments with processed ones
+ */
+HtmlWebpackPlugin.prototype.applyPluginsAsyncWaterfall = function (compilation) {
+  var promisedApplyPluginsAsyncWaterfall = Promise.promisify(compilation.applyPluginsAsyncWaterfall, {context: compilation});
+  return function (eventName, pluginArgs) {
+    return promisedApplyPluginsAsyncWaterfall(eventName, pluginArgs)
+      .then(function (result) {
+        return _.extend(pluginArgs, result);
+      });
+  };
 };
 
 module.exports = HtmlWebpackPlugin;

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -747,7 +747,7 @@ describe('HtmlWebpackPlugin', function () {
     }, [], null, function () {
       expect(eventFired).toBe(true);
       done();
-    });
+    }, false, true);
   });
 
   it('fires the html-webpack-plugin-before-html-processing event', function (done) {
@@ -777,7 +777,7 @@ describe('HtmlWebpackPlugin', function () {
     }, [], null, function () {
       expect(eventFired).toBe(true);
       done();
-    });
+    }, false, true);
   });
 
   it('fires the html-webpack-plugin-after-html-processing event', function (done) {
@@ -807,7 +807,7 @@ describe('HtmlWebpackPlugin', function () {
     }, [], null, function () {
       expect(eventFired).toBe(true);
       done();
-    });
+    }, false, true);
   });
 
   it('fires the html-webpack-plugin-after-emit event', function (done) {
@@ -837,7 +837,7 @@ describe('HtmlWebpackPlugin', function () {
     }, [], null, function () {
       expect(eventFired).toBe(true);
       done();
-    });
+    }, false, true);
   });
 
   it('allows to modify the html during html-webpack-plugin-after-html-processing event', function (done) {
@@ -868,7 +868,7 @@ describe('HtmlWebpackPlugin', function () {
     }, ['Injected by plugin'], null, function () {
       expect(eventFired).toBe(true);
       done();
-    });
+    }, false, true);
   });
 
   it('allows to modify sequentially the html during html-webpack-plugin-after-html-processing event by edit the given arguments object', function (done) {
@@ -914,7 +914,7 @@ describe('HtmlWebpackPlugin', function () {
       expect(eventFiredForFirstPlugin).toBe(true);
       expect(eventFiredForSecondPlugin).toBe(true);
       done();
-    });
+    }, false, true);
   });
 
   it('allows to modify sequentially the html during html-webpack-plugin-after-html-processing event either by edit the given arguments object or by return a new object in the callback', function (done) {
@@ -962,7 +962,7 @@ describe('HtmlWebpackPlugin', function () {
       expect(eventFiredForFirstPlugin).toBe(true);
       expect(eventFiredForSecondPlugin).toBe(true);
       done();
-    });
+    }, false, true);
   });
 
   it('allows to modify sequentially the html during html-webpack-plugin-after-html-processing event by return a new object in the callback', function (done) {
@@ -1044,7 +1044,7 @@ describe('HtmlWebpackPlugin', function () {
     }, ['Injected by plugin', '<script type="text/javascript" src="funky-script.js"'], null, function () {
       expect(eventFired).toBe(true);
       done();
-    });
+    }, false, true);
   });
 
   it('allows to modify the html during html-webpack-plugin-before-html-generation event', function (done) {
@@ -1078,7 +1078,7 @@ describe('HtmlWebpackPlugin', function () {
     }, ['<script type="text/javascript" src="funky-script.js"'], null, function () {
       expect(eventFired).toBe(true);
       done();
-    });
+    }, false, true);
   });
 
   it('works with commons chunk plugin', function (done) {

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -15,6 +15,7 @@ var path = require('path');
 var fs = require('fs');
 var webpack = require('webpack');
 var rimraf = require('rimraf');
+var _ = require('lodash');
 var CommonsChunkPlugin = require('webpack/lib/optimize/CommonsChunkPlugin');
 var HtmlWebpackPlugin = require('../index.js');
 
@@ -870,7 +871,7 @@ describe('HtmlWebpackPlugin', function () {
     });
   });
 
-  it('allows to modify sequentially the html during html-webpack-plugin-after-html-processing event', function (done) {
+  it('allows to modify sequentially the html during html-webpack-plugin-after-html-processing event by edit the given arguments object', function (done) {
     var eventFiredForFirstPlugin = false;
     var eventFiredForSecondPlugin = false;
     var examplePlugin = {
@@ -891,6 +892,104 @@ describe('HtmlWebpackPlugin', function () {
             eventFiredForSecondPlugin = true;
             object.html += ' Injected by second plugin';
             callback(null);
+          });
+        });
+      }
+    };
+
+    testHtmlPlugin({
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        examplePlugin,
+        secondExamplePlugin
+      ]
+    }, ['Injected by first plugin Injected by second plugin'], null, function () {
+      expect(eventFiredForFirstPlugin).toBe(true);
+      expect(eventFiredForSecondPlugin).toBe(true);
+      done();
+    });
+  });
+
+  it('allows to modify sequentially the html during html-webpack-plugin-after-html-processing event either by edit the given arguments object or by return a new object in the callback', function (done) {
+    var eventFiredForFirstPlugin = false;
+    var eventFiredForSecondPlugin = false;
+    var examplePlugin = {
+      apply: function (compiler) {
+        compiler.plugin('compilation', function (compilation) {
+          compilation.plugin('html-webpack-plugin-after-html-processing', function (object, callback) {
+            eventFiredForFirstPlugin = true;
+            var result = _.extend(object, {
+              html: object.html + 'Injected by first plugin'
+            });
+            callback(null, result);
+          });
+        });
+      }
+    };
+    var secondExamplePlugin = {
+      apply: function (compiler) {
+        compiler.plugin('compilation', function (compilation) {
+          compilation.plugin('html-webpack-plugin-after-html-processing', function (object, callback) {
+            eventFiredForSecondPlugin = true;
+            object.html += ' Injected by second plugin';
+            callback(null);
+          });
+        });
+      }
+    };
+
+    testHtmlPlugin({
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        examplePlugin,
+        secondExamplePlugin
+      ]
+    }, ['Injected by first plugin Injected by second plugin'], null, function () {
+      expect(eventFiredForFirstPlugin).toBe(true);
+      expect(eventFiredForSecondPlugin).toBe(true);
+      done();
+    });
+  });
+
+  it('allows to modify sequentially the html during html-webpack-plugin-after-html-processing event by return a new object in the callback', function (done) {
+    var eventFiredForFirstPlugin = false;
+    var eventFiredForSecondPlugin = false;
+    var examplePlugin = {
+      apply: function (compiler) {
+        compiler.plugin('compilation', function (compilation) {
+          compilation.plugin('html-webpack-plugin-after-html-processing', function (object, callback) {
+            eventFiredForFirstPlugin = true;
+            var result = _.extend(object, {
+              html: object.html + 'Injected by first plugin'
+            });
+            callback(null, result);
+          });
+        });
+      }
+    };
+    var secondExamplePlugin = {
+      apply: function (compiler) {
+        compiler.plugin('compilation', function (compilation) {
+          compilation.plugin('html-webpack-plugin-after-html-processing', function (object, callback) {
+            eventFiredForSecondPlugin = true;
+            var result = _.extend(object, {
+              html: object.html + ' Injected by second plugin'
+            });
+            callback(null, result);
           });
         });
       }

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -870,6 +870,52 @@ describe('HtmlWebpackPlugin', function () {
     });
   });
 
+  it('allows to modify sequentially the html during html-webpack-plugin-after-html-processing event', function (done) {
+    var eventFiredForFirstPlugin = false;
+    var eventFiredForSecondPlugin = false;
+    var examplePlugin = {
+      apply: function (compiler) {
+        compiler.plugin('compilation', function (compilation) {
+          compilation.plugin('html-webpack-plugin-after-html-processing', function (object, callback) {
+            eventFiredForFirstPlugin = true;
+            object.html += 'Injected by first plugin';
+            callback(null, object);
+          });
+        });
+      }
+    };
+    var secondExamplePlugin = {
+      apply: function (compiler) {
+        compiler.plugin('compilation', function (compilation) {
+          compilation.plugin('html-webpack-plugin-after-html-processing', function (object, callback) {
+            eventFiredForSecondPlugin = true;
+            object.html += ' Injected by second plugin';
+            callback(null);
+          });
+        });
+      }
+    };
+
+    testHtmlPlugin({
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        examplePlugin,
+        secondExamplePlugin
+      ]
+    }, ['Injected by first plugin Injected by second plugin'], null, function () {
+      expect(eventFiredForFirstPlugin).toBe(true);
+      expect(eventFiredForSecondPlugin).toBe(true);
+      done();
+    });
+  });
+
   it('allows to modify the html during html-webpack-plugin-before-html-processing event', function (done) {
     var eventFired = false;
     var examplePlugin = {


### PR DESCRIPTION
Hi @jantimon,
I came up with this simple solution to satisfy both needs.
This approach:
 - keep backwards compatibility
 - offer a new api to deal with `html-webpack-plugin-(before|after)-html-processing`



