### PR TITLE
Fix missing context for template path resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -594,7 +594,7 @@ HtmlWebpackPlugin.prototype.getFullTemplatePath = function (template, context) {
   return template.replace(
     /([!])([^\/\\][^!\?]+|[^\/\\!?])($|\?.+$)/,
     function (match, prefix, filepath, postfix) {
-      return prefix + path.resolve(filepath) + postfix;
+      return prefix + path.resolve(context, filepath) + postfix;
     });
 };
 


### PR DESCRIPTION
Relative template paths wasn't resolved correctly when used with loaders.