### PR TITLE
Add an option that prevents head tag from being generated automatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Allowed values are as follows:
   included scripts and CSS files. This is useful for cache busting.
 - `cache`: `true | false` if `true` (default) try to emit the file only if it was changed.
 - `showErrors`: `true | false` if `true` (default) errors details will be written into the html page.
-- `createMissingTags`: `true | false` if `true` whether to create a `<head>` tag ( if it does not exists ) when injecting assets. default: 'true'
+- `createMissingTags`: `true | false` if `true` and `<head>` tag is missing in the html, create one when injecting assets. default: 'true'
 - `chunks`: Allows you to add only some chunks (e.g. only the unit-test chunk)
 - `chunksSortMode`: Allows to control how chunks should be sorted before they are included to the html. Allowed values: 'none' | 'auto' | 'dependency' | {function} - default: 'auto'
 - `excludeChunks`: Allows you to skip some chunks (e.g. don't add the unit-test chunk)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Allowed values are as follows:
   included scripts and CSS files. This is useful for cache busting.
 - `cache`: `true | false` if `true` (default) try to emit the file only if it was changed.
 - `showErrors`: `true | false` if `true` (default) errors details will be written into the html page.
+- `createMissingTags`: `true | false` if `true` whether to create a `<head>` tag ( if it does not exists ) when injecting assets. default: 'true'
 - `chunks`: Allows you to add only some chunks (e.g. only the unit-test chunk)
 - `chunksSortMode`: Allows to control how chunks should be sorted before they are included to the html. Allowed values: 'none' | 'auto' | 'dependency' | {function} - default: 'auto'
 - `excludeChunks`: Allows you to skip some chunks (e.g. don't add the unit-test chunk)

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ function HtmlWebpackPlugin (options) {
     minify: false,
     cache: true,
     showErrors: true,
+    createMissingTags: true,
     chunks: 'all',
     excludeChunks: [],
     title: 'Webpack App',
@@ -531,20 +532,25 @@ HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function (html, assets, asset
 
   if (head.length) {
     // Create a head tag if none exists
-    if (!headRegExp.test(html)) {
+    if (this.options.createMissingTags && !headRegExp.test(html)) {
       if (!htmlRegExp.test(html)) {
+        // prepend 'head' tag to the 'html' if there's no 'html' tag.
         html = '<head></head>' + html;
       } else {
+        // append 'head' tag to 'html' tag.
         html = html.replace(htmlRegExp, function (match) {
           return match + '<head></head>';
         });
       }
-    }
 
-    // Append assets to head element
-    html = html.replace(headRegExp, function (match) {
-      return head.join('') + match;
-    });
+      // Append assets to head element
+      html = html.replace(headRegExp, function (match) {
+        return head.join('') + match;
+      });
+    } else {
+      // add scripts to the begining of the file when no <head> tag element exists.
+      html = head.join('') + html;
+    }
   }
 
   // Inject manifest into the opening html tag

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -313,6 +313,53 @@ describe('HtmlWebpackPlugin', function () {
     }], null, done);
   });
 
+  it('creates missing head tag by default', function (done) {
+    var ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }
+        ]
+      },
+      plugins: [
+        new ExtractTextPlugin('styles.css'),
+        new HtmlWebpackPlugin({
+          filename: 'head-tag-test.html',
+          template: path.join(__dirname, 'fixtures/empty_html.html')
+        })]
+    }, [/<head>/gm], 'head-tag-test.html', done);
+  });
+
+  it('allows you to prevent the creation of missing head tag', function (done) {
+    var ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }
+        ]
+      },
+      plugins: [
+        new ExtractTextPlugin('styles.css'),
+        new HtmlWebpackPlugin({
+          createMissingTags: false,
+          filename: 'head-tag-test.html',
+          template: path.join(__dirname, 'fixtures/empty_html.html')
+        })]
+    }, [/^((?!<head>).)*$/gmi], 'head-tag-test.html', done);
+  });
+
   it('allows you to disable injection', function (done) {
     testHtmlPlugin({
       entry: {


### PR DESCRIPTION
**Description:**
When working with this plugin to generate multiple html files for a single-page-application
Missing `<head></head>` tags are added to the output.

**Issue:**
single page applications usually have a wireframe html file serving as the base / entry point, and multiple html files with nothing but raw html ( no html / body tags ).

The current way this plugin injects assets designated to the head section of a document, is to check whether an appropriate `<head>` tag exists before adding the relevant resources.
This can be problematic, since it can result in two files having `<head>` tags.

For example when entering the first page in an SPA: 
 - wireframe.html is processed and now contains `<head>` tag
 - profile.html is processed and now also contains a `<head>` tag

Such a scenario can create an invalid html layout.

I added an option called "createMissingTags" and set its default value to 'true'
This will make sure no breaking changes are added to the code base, and introduce an option
That will allow future control on the creating of missing tags in a scope larger than just the `<head>` 

I also added unit tests for this, as well as updated the docs.

Thoughts? 