### PR TITLE
Add the ability to exclude assets based on RegExp patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Allowed values are as follows:
 - `chunksSortMode`: Allows to control how chunks should be sorted before they are included to the html. Allowed values: 'none' | 'auto' | 'dependency' | {function} - default: 'auto'
 - `excludeChunks`: Allows you to skip some chunks (e.g. don't add the unit-test chunk)
 - `xhtml`: `true | false` If `true` render the `link` tags as self-closing, XHTML compliant. Default is `false`
-- `excludeAssets`: `RegExp` Allows you to skip some assets (e.g. if you add a `style` as webpack's entry with value `['some-3rd-party-styles.css']` and want to skip the `style.js`)
+- `excludeAssets`: `[RegExp]` Allows you to skip some assets (e.g. if you add a `style` as webpack's entry with value `['some-3rd-party-styles.css']` and want to skip the `style.js` but keep `style.css`)
 
 Here's an example webpack config illustrating how to use these options:
 ```javascript
@@ -248,6 +248,23 @@ plugins: [
   })
 ]
 ```
+
+
+Filtering assets
+----------------
+
+To exclude certain assets by setting the `excludeAssets` option:
+
+```javascript
+plugins: [
+  new HtmlWebpackPlugin({
+    excludeAssets: [/style.*.js/]
+  })
+]
+```
+
+Use case: If you have a seprate entry of webpack, for example `style` for third party css libraries, such as Bootstrap, and you want to exclude the `style.js` or the `style.[chunkhash].js`, you can use this option to archive that.
+
 
 Events
 ------

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Allowed values are as follows:
 - `chunksSortMode`: Allows to control how chunks should be sorted before they are included to the html. Allowed values: 'none' | 'auto' | 'dependency' | {function} - default: 'auto'
 - `excludeChunks`: Allows you to skip some chunks (e.g. don't add the unit-test chunk)
 - `xhtml`: `true | false` If `true` render the `link` tags as self-closing, XHTML compliant. Default is `false`
+- `excludeAssets`: `RegExp` Allows you to skip some assets (e.g. if you add a `style` as webpack's entry with value `['some-3rd-party-styles.css']` and want to skip the `style.js`)
 
 Here's an example webpack config illustrating how to use these options:
 ```javascript

--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ function HtmlWebpackPlugin (options) {
     chunks: 'all',
     excludeChunks: [],
     title: 'Webpack App',
-    xhtml: false
+    xhtml: false,
+    excludeAssets: []
   }, options);
 }
 
@@ -464,8 +465,21 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
  * Injects the assets into the given html string
  */
 HtmlWebpackPlugin.prototype.generateAssetTags = function (assets) {
+  // Skip invalid RegExp patterns
+  var excludePatterns = this.options.excludeAssets.filter(function (excludePattern) {
+    return excludePattern.constructor === RegExp;
+  });
+
+  var isExcluded = function (assetPath) {
+    return excludePatterns.filter(function (excludePattern) {
+      return excludePattern.test(assetPath);
+    }).length > 0;
+  };
+
   // Turn script files into script tags
-  var scripts = assets.js.map(function (scriptPath) {
+  var scripts = assets.js.filter(function (scriptPath) {
+    return !isExcluded(scriptPath);
+  }).map(function (scriptPath) {
     return {
       tagName: 'script',
       closeTag: true,
@@ -478,7 +492,9 @@ HtmlWebpackPlugin.prototype.generateAssetTags = function (assets) {
   // Make tags self-closing in case of xhtml
   var selfClosingTag = !!this.options.xhtml;
   // Turn css files into link tags
-  var styles = assets.css.map(function (stylePath) {
+  var styles = assets.css.filter(function (stylePath) {
+    return !isExcluded(stylePath);
+  }).map(function (stylePath) {
     return {
       tagName: 'link',
       selfClosingTag: selfClosingTag,


### PR DESCRIPTION
When adding an entry, for example `style: ['bootstrap/dist/css/bootstrap.css']`, with third party css files to webpack, the injected scripts include `style.js` or `style.[chunkhash].js`. The `excludeChunks` will exclude both `style.css` and `style.js`. With `excludeAssets`, you can keep `style.css` in and `style.js` out.