### PR TITLE
Enable unvalued element attributes - with a simpler test

### DIFF
--- a/index.js
+++ b/index.js
@@ -582,7 +582,8 @@ HtmlWebpackPlugin.prototype.appendHash = function (url, hash) {
  */
 HtmlWebpackPlugin.prototype.createHtmlTag = function (tagDefinition) {
   var attributes = Object.keys(tagDefinition.attributes || {}).map(function (attributeName) {
-    return attributeName + '="' + tagDefinition.attributes[attributeName] + '"';
+    const value = tagDefinition.attributes[attributeName];
+    return value ? attributeName + '="' + tagDefinition.attributes[attributeName] + '"' : attributeName;
   });
   return '<' + [tagDefinition.tagName].concat(attributes).join(' ') + (tagDefinition.selfClosingTag ? '/' : '') + '>' +
     (tagDefinition.innerHTML || '') +

--- a/spec/AddOnSpec.js
+++ b/spec/AddOnSpec.js
@@ -1,0 +1,123 @@
+/*
+ * Integration and unit tests for all features but caching
+ */
+
+/* eslint-env jasmine */
+'use strict';
+
+// Workaround for css-loader issue
+// https://github.com/webpack/css-loader/issues/144
+if (!global.Promise) {
+  require('es6-promise').polyfill();
+}
+
+var path = require('path');
+var fs = require('fs');
+var webpack = require('webpack');
+var rimraf = require('rimraf');
+var HtmlWebpackPlugin = require('../index.js');
+
+var OUTPUT_DIR = path.join(__dirname, '../dist');
+
+jasmine.getEnv().defaultTimeoutInterval = 30000;
+
+function testHtmlPlugin (webpackConfig, expectedResults, outputFile, done, expectErrors, expectWarnings) {
+  outputFile = outputFile || 'index.html';
+  webpack(webpackConfig, function (err, stats) {
+    expect(err).toBeFalsy();
+    var compilationErrors = (stats.compilation.errors || []).join('\n');
+    if (expectErrors) {
+      expect(compilationErrors).not.toBe('');
+    } else {
+      expect(compilationErrors).toBe('');
+    }
+    var compilationWarnings = (stats.compilation.warnings || []).join('\n');
+    if (expectWarnings) {
+      expect(compilationWarnings).not.toBe('');
+    } else {
+      expect(compilationWarnings).toBe('');
+    }
+    if (outputFile instanceof RegExp) {
+      var matches = Object.keys(stats.compilation.assets).filter(function (item) {
+        return outputFile.test(item);
+      });
+      expect(matches.length).toBe(1);
+      outputFile = matches[0];
+    }
+    expect(outputFile.indexOf('[hash]') === -1).toBe(true);
+    var outputFileExists = fs.existsSync(path.join(OUTPUT_DIR, outputFile));
+    expect(outputFileExists).toBe(true);
+    if (!outputFileExists) {
+      return done();
+    }
+    var htmlContent = fs.readFileSync(path.join(OUTPUT_DIR, outputFile)).toString();
+    var chunksInfo;
+    for (var i = 0; i < expectedResults.length; i++) {
+      var expectedResult = expectedResults[i];
+      if (expectedResult instanceof RegExp) {
+        expect(htmlContent).toMatch(expectedResult);
+      } else if (typeof expectedResult === 'object') {
+        if (expectedResult.type === 'chunkhash') {
+          if (!chunksInfo) {
+            chunksInfo = getChunksInfoFromStats(stats);
+          }
+          var chunkhash = chunksInfo[expectedResult.chunkName].hash;
+          expect(htmlContent).toContain(expectedResult.containStr.replace('%chunkhash%', chunkhash));
+        }
+      } else {
+        expect(htmlContent).toContain(expectedResult.replace('%hash%', stats.hash));
+      }
+    }
+    done();
+  });
+}
+
+function getChunksInfoFromStats (stats) {
+  var chunks = stats.compilation.getStats().toJson().chunks;
+  var chunksInfo = {};
+  for (var i = 0; i < chunks.length; i++) {
+    var chunk = chunks[i];
+    var chunkName = chunk.names[0];
+    if (chunkName) {
+      chunksInfo[chunkName] = chunk;
+    }
+  }
+  return chunksInfo;
+}
+
+describe('HtmlWebpackPlugin AddOn Plugins', function () {
+  beforeEach(function (done) {
+    rimraf(OUTPUT_DIR, done);
+  });
+
+  it('can add a no-value attribute to an HTML element', function (done) {
+    const addOnPlugin = {
+      apply: function (compiler) {
+        compiler.plugin('compilation', compilation => {
+          compilation.plugin('html-webpack-plugin-alter-asset-tags', (pluginArgs, callback) => {
+            pluginArgs.body = pluginArgs.body.map(tag => {
+              if (tag.tagName === 'script') {
+                Object.defineProperty(tag.attributes, 'async', {enumerable: true});
+              }
+              return tag;
+            });
+            callback(null, pluginArgs);
+          });
+        });
+      }
+    };
+    testHtmlPlugin(
+      {
+        entry: path.join(__dirname, 'fixtures/index.js'),
+        output: {
+          path: OUTPUT_DIR,
+          filename: 'index_bundle.js'
+        },
+        plugins: [new HtmlWebpackPlugin(), addOnPlugin]
+      },
+      [/<body>[\s]*<script type="text\/javascript" src="index_bundle.js" async><\/script>[\s]*<\/body>/],
+      null,
+      done
+    );
+  });
+});

--- a/spec/AddOnSpec.js
+++ b/spec/AddOnSpec.js
@@ -1,5 +1,5 @@
 /*
- * Integration and unit tests for all features but caching
+ * Integration and unit tests for add-on plugin functionality
  */
 
 /* eslint-env jasmine */
@@ -11,78 +11,40 @@ if (!global.Promise) {
   require('es6-promise').polyfill();
 }
 
-var path = require('path');
-var fs = require('fs');
-var webpack = require('webpack');
-var rimraf = require('rimraf');
-var HtmlWebpackPlugin = require('../index.js');
+const path = require('path');
+const fs = require('fs');
+const webpack = require('webpack');
+const rimraf = require('rimraf');
+const HtmlWebpackPlugin = require('../index.js');
 
-var OUTPUT_DIR = path.join(__dirname, '../dist');
+const OUTPUT_DIR = path.join(__dirname, '../dist');
 
 jasmine.getEnv().defaultTimeoutInterval = 30000;
 
-function testHtmlPlugin (webpackConfig, expectedResults, outputFile, done, expectErrors, expectWarnings) {
-  outputFile = outputFile || 'index.html';
+function testHtmlPlugin (webpackConfig, expectedResult, done) {
+  const outputFile = path.join(OUTPUT_DIR, 'index.html');
   webpack(webpackConfig, function (err, stats) {
     expect(err).toBeFalsy();
-    var compilationErrors = (stats.compilation.errors || []).join('\n');
-    if (expectErrors) {
-      expect(compilationErrors).not.toBe('');
-    } else {
-      expect(compilationErrors).toBe('');
-    }
-    var compilationWarnings = (stats.compilation.warnings || []).join('\n');
-    if (expectWarnings) {
-      expect(compilationWarnings).not.toBe('');
-    } else {
-      expect(compilationWarnings).toBe('');
-    }
-    if (outputFile instanceof RegExp) {
-      var matches = Object.keys(stats.compilation.assets).filter(function (item) {
-        return outputFile.test(item);
-      });
-      expect(matches.length).toBe(1);
-      outputFile = matches[0];
-    }
-    expect(outputFile.indexOf('[hash]') === -1).toBe(true);
-    var outputFileExists = fs.existsSync(path.join(OUTPUT_DIR, outputFile));
+    expect(stats.compilation.errors.length).toEqual(0);
+    expect(stats.compilation.warnings.length).toEqual(0);
+    const outputFileExists = fs.existsSync(outputFile);
     expect(outputFileExists).toBe(true);
-    if (!outputFileExists) {
-      return done();
-    }
-    var htmlContent = fs.readFileSync(path.join(OUTPUT_DIR, outputFile)).toString();
-    var chunksInfo;
-    for (var i = 0; i < expectedResults.length; i++) {
-      var expectedResult = expectedResults[i];
-      if (expectedResult instanceof RegExp) {
-        expect(htmlContent).toMatch(expectedResult);
-      } else if (typeof expectedResult === 'object') {
-        if (expectedResult.type === 'chunkhash') {
-          if (!chunksInfo) {
-            chunksInfo = getChunksInfoFromStats(stats);
-          }
-          var chunkhash = chunksInfo[expectedResult.chunkName].hash;
-          expect(htmlContent).toContain(expectedResult.containStr.replace('%chunkhash%', chunkhash));
-        }
-      } else {
-        expect(htmlContent).toContain(expectedResult.replace('%hash%', stats.hash));
-      }
+    if (outputFileExists) {
+      const htmlContent = fs.readFileSync(outputFile).toString();
+      expect(htmlContent).toMatch(expectedResult);
     }
     done();
   });
 }
 
-function getChunksInfoFromStats (stats) {
-  var chunks = stats.compilation.getStats().toJson().chunks;
-  var chunksInfo = {};
-  for (var i = 0; i < chunks.length; i++) {
-    var chunk = chunks[i];
-    var chunkName = chunk.names[0];
-    if (chunkName) {
-      chunksInfo[chunkName] = chunk;
+function createTestPlugin (addOnEvent, testFn) {
+  return {
+    apply: function (compiler) {
+      compiler.plugin('compilation', compilation => {
+        compilation.plugin(addOnEvent, testFn);
+      });
     }
-  }
-  return chunksInfo;
+  };
 }
 
 describe('HtmlWebpackPlugin AddOn Plugins', function () {
@@ -91,33 +53,27 @@ describe('HtmlWebpackPlugin AddOn Plugins', function () {
   });
 
   it('can add a no-value attribute to an HTML element', function (done) {
-    const addOnPlugin = {
-      apply: function (compiler) {
-        compiler.plugin('compilation', compilation => {
-          compilation.plugin('html-webpack-plugin-alter-asset-tags', (pluginArgs, callback) => {
-            pluginArgs.body = pluginArgs.body.map(tag => {
-              if (tag.tagName === 'script') {
-                Object.defineProperty(tag.attributes, 'async', {enumerable: true});
-              }
-              return tag;
-            });
-            callback(null, pluginArgs);
-          });
-        });
-      }
+    const testFn = (pluginArgs, callback) => {
+      pluginArgs.body = pluginArgs.body.map(tag => {
+        if (tag.tagName === 'script') {
+          Object.defineProperty(tag.attributes, 'async', {enumerable: true});
+        }
+        return tag;
+      });
+      callback(null, pluginArgs);
     };
-    testHtmlPlugin(
-      {
-        entry: path.join(__dirname, 'fixtures/index.js'),
-        output: {
-          path: OUTPUT_DIR,
-          filename: 'index_bundle.js'
-        },
-        plugins: [new HtmlWebpackPlugin(), addOnPlugin]
+    const webpackConfig = {
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
       },
-      [/<body>[\s]*<script type="text\/javascript" src="index_bundle.js" async><\/script>[\s]*<\/body>/],
-      null,
-      done
-    );
+      plugins: [
+        new HtmlWebpackPlugin(),
+        createTestPlugin('html-webpack-plugin-alter-asset-tags', testFn)
+      ]
+    };
+    const expectedResult = /<body>[\s]*<script type="text\/javascript" src="index_bundle.js" async><\/script>[\s]*<\/body>/;
+    testHtmlPlugin(webpackConfig, expectedResult, done);
   });
 });


### PR DESCRIPTION
Alternative to [PR 514](https://github.com/ampedandwired/html-webpack-plugin/pull/514) - same (trivial) functional change but a much simpler AddOnSpec - in response to @jantimon's [comments](https://github.com/ampedandwired/html-webpack-plugin/pull/514#issuecomment-268216105).