### PR TITLE
Allow config to specify the hash's query string variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Allowed values are as follows:
 - `inject`: `true | 'head' | 'body' | false` Inject all assets into the given `template` or `templateContent` - When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element.
 - `favicon`: Adds the given favicon path to the output html.
 - `minify`: `{...} | false` Pass a [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference) options object to minify the output.
-- `hash`: `true | false` if `true` then append a unique webpack compilation hash to all
-  included scripts and CSS files. This is useful for cache busting.
+- `hash`: `true | 'string' | false` if `true` then append a unique webpack compilation hash to all
+  included scripts and CSS files. This is useful for cache busting. If a string is specified, use that string as the query string variable that contains the compilation hash
 - `cache`: `true | false` if `true` (default) try to emit the file only if it was changed.
 - `showErrors`: `true | false` if `true` (default) errors details will be written into the HTML page.
 - `chunks`: Allows you to add only some chunks (e.g. only the unit-test chunk)

--- a/index.js
+++ b/index.js
@@ -413,8 +413,8 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
 
   // Append a hash for cache busting
   if (this.options.hash) {
-    assets.manifest = self.appendHash(assets.manifest, webpackStatsJson.hash);
-    assets.favicon = self.appendHash(assets.favicon, webpackStatsJson.hash);
+    assets.manifest = self.appendHash(assets.manifest, webpackStatsJson.hash, this.options.hash);
+    assets.favicon = self.appendHash(assets.favicon, webpackStatsJson.hash, this.options.hash);
   }
 
   for (var i = 0; i < chunks.length; i++) {
@@ -431,7 +431,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
     // Append a hash for cache busting
     if (this.options.hash) {
       chunkFiles = chunkFiles.map(function (chunkFile) {
-        return self.appendHash(chunkFile, webpackStatsJson.hash);
+        return self.appendHash(chunkFile, webpackStatsJson.hash, self.options.hash);
       });
     }
 
@@ -569,12 +569,17 @@ HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function (html, assets, asset
 
 /**
  * Appends a cache busting hash
+ * If qsv is a string, use that as the cache busting hash variable
  */
-HtmlWebpackPlugin.prototype.appendHash = function (url, hash) {
+HtmlWebpackPlugin.prototype.appendHash = function (url, hash, qsv) {
+  var finalHash = hash;
+  if (typeof qsv === 'string') {
+    finalHash = qsv + '=' + hash;
+  }
   if (!url) {
     return url;
   }
-  return url + (url.indexOf('?') === -1 ? '?' : '&') + hash;
+  return url + (url.indexOf('?') === -1 ? '?' : '&') + finalHash;
 };
 
 /**

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -465,6 +465,26 @@ describe('HtmlWebpackPlugin', function () {
     }, ['<link href="styles.css?%hash%"'], null, done);
   });
 
+  it('should allow adding cache hashes to assets with a given query string name', function (done) {
+    var ExtractTextPlugin = require('extract-text-webpack-plugin');
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }
+        ]
+      },
+      plugins: [
+        new HtmlWebpackPlugin({hash: '_version'}),
+        new ExtractTextPlugin('styles.css')
+      ]
+    }, ['<link href="styles.css?_version=%hash%"'], null, done);
+  });
+
   it('should inject css files when using the extract text plugin', function (done) {
     var ExtractTextPlugin = require('extract-text-webpack-plugin');
     testHtmlPlugin({


### PR DESCRIPTION
I'd like to be able to set the the query string variable for caching, so that if I specify a whitelist of cache busting query string variables in CloudFront, I can use this plugin to automatically bust the CloudFront cache.

Hopefully this is a good change 👍 