### PR TITLE
Fix template compilation for es6 modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,6 +233,9 @@ HtmlWebpackPlugin.prototype.evaluateCompilationResult = function (compilation, s
   } catch (e) {
     return Promise.reject(e);
   }
+  if (typeof newSource === 'object' && newSource.__esModule && newSource.default) {
+    newSource = newSource.default;
+  }
   return typeof newSource === 'string' || typeof newSource === 'function'
     ? Promise.resolve(newSource)
     : Promise.reject('The loader "' + this.options.template + '" didn\'t return html.');


### PR DESCRIPTION
Add support for JS template with:
```js
export default (templateParams) => ...
```