### PR TITLE
Fix travis-ci: set tty size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ node_js:
   - "6"
 env:
   - WEBPACK=webpack
+before_install:
+  - stty columns 120
 install:
   - npm install --ignore-scripts
   - npm rm webpack


### PR DESCRIPTION
`PrettyErrors`'s  dependecy `RenderKid` needs TTY columns to word-wrap lines to console.