### PR TITLE
Create explicit loader path

### DIFF
--- a/index.js
+++ b/index.js
@@ -605,7 +605,7 @@ HtmlWebpackPlugin.prototype.createHtmlTag = function (tagDefinition) {
 HtmlWebpackPlugin.prototype.getFullTemplatePath = function (template, context) {
   // If the template doesn't use a loader use the lodash template loader
   if (template.indexOf('!') === -1) {
-    template = 'html-webpack-plugin/lib/loader.js!' + path.resolve(context, template);
+    template = path.join(__dirname, 'lib/loader.js') + '!' + path.resolve(context, template);
   }
   // Resolve template path
   return template.replace(


### PR DESCRIPTION
# Problem

The `html-webpack-plugin/lib/loader.js` path assumes `html-webpack-plugin` will be found where webpack runs, except in some rare cases it isn't so. In Lerna setups like that of [react-cosmos](https://github.com/react-cosmos/react-cosmos), you can have one package have `html-webpack-plugin` as a dep and another package have `webpack` as a dep. Because the way packages are linked in this setup they each have their own node_modules bucket and deps installed on one side aren't found in the other (until lib is actually published and user installs, then everything ends up normalized in the same node_modules dir).

# Solution

By pinning down the exact path this problem disappears. Can't think of any downside and all tests pass. Thoughts?

Thanks! 