### PR TITLE
fix(chunksorter): webpack2 compatible

### DIFF
--- a/lib/chunksorter.js
+++ b/lib/chunksorter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var toposort = require('toposort');
+var _ = require('lodash');
 
 /*
   Sorts dependencies between chunks by their "parents" attribute.
@@ -40,7 +41,8 @@ module.exports.dependency = function (chunks) {
     if (chunk.parents) {
       // Add an edge for each parent (parent -> child)
       chunk.parents.forEach(function (parentId) {
-        var parentChunk = nodeMap[parentId];
+        // webpack2 chunk.parents are chunks instead of string id(s)
+        var parentChunk = _.isObject(parentId) ? parentId : nodeMap[parentId];
         // If the parent chunk does not exist (e.g. because of an excluded chunk)
         // we ignore that parent
         if (parentChunk) {


### PR DESCRIPTION
- [x] webpack2 compatible chunksortet

`chunk.parents` are insurance of `Chunk` instead of string `id`(s):

This PR supports both webpack1 and webpack2.

Some example from webpack:
https://github.com/webpack/webpack/blob/b07dc3da275402d7128c06d762e840f25b31c54c/lib/optimize/CommonsChunkPlugin.js#L165
https://github.com/webpack/webpack/blob/028c51301733836abbedc88be7483af2623f5943/lib/Chunk.js#L141