### PR TITLE
chunks passed to alter-assets event

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,6 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
       .then(function (result) {
         var html = result.html;
         var assets = result.assets;
-        var chunks = result.chunks;
         // Prepare script and link tags
         var assetTags = self.generateAssetTags(assets);
         var pluginArgs = {head: assetTags.head, body: assetTags.body, plugin: self, chunks: chunks, outputName: self.childCompilationOutputName};

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -750,6 +750,36 @@ describe('HtmlWebpackPlugin', function () {
     }, false, true);
   });
 
+  it('passes chunks to the html-webpack-plugin-alter-asset-tags event', function (done) {
+    var chunks;
+    var examplePlugin = {
+      apply: function (compiler) {
+        compiler.plugin('compilation', function (compilation) {
+          compilation.plugin('html-webpack-plugin-alter-asset-tags', function (object, callback) {
+            chunks = object.chunks;
+            callback();
+          });
+        });
+      }
+    };
+    testHtmlPlugin({
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        examplePlugin
+      ]
+    }, [], null, function () {
+      expect(chunks).toBeDefined();
+      done();
+    }, false, true);
+  });
+
   it('allows events to add a no-value attribute', function (done) {
     var examplePlugin = {
       apply: function (compiler) {


### PR DESCRIPTION
Minor bug fix to ensure `chunks` param passed to `alter-assets` event - will also allow implementation of  [style-ext-html-webpack-plugin](https://github.com/numical/style-ext-html-webpack-plugin) to be simplified.